### PR TITLE
refactor: isolate example apps into dc_example schema

### DIFF
--- a/data_collector/examples/captcha/check_balance/main.py
+++ b/data_collector/examples/captcha/check_balance/main.py
@@ -33,7 +33,7 @@ from data_collector.settings.captcha import CaptchaSettings
 from data_collector.settings.main import LogSettings
 from data_collector.tables.apps import AppGroups, AppParents, Apps
 from data_collector.tables.captcha import CaptchaLog
-from data_collector.tables.deploy import Deploy
+from data_collector.tables.deploy import ExampleDeploy
 from data_collector.tables.runtime import Runtime
 from data_collector.utilities.database.main import Database
 from data_collector.utilities.fun_watch import FunWatchMixin, FunWatchRegistry, fun_watch
@@ -137,7 +137,6 @@ def _register_app(database: Database, app_info: AppInfo) -> None:
                 run_status=RunStatus.NOT_RUNNING,
                 fatal_flag=FatalFlag.NONE,
                 disable=True,
-                managed=False,
             ),
             session,
             filter_cols=["group_name", "parent_name", "app_name"],
@@ -178,9 +177,10 @@ def main() -> None:
 
     FunWatchRegistry.reset()
 
-    deploy = Deploy()
+    deploy = ExampleDeploy()
     deploy.create_tables()
     deploy.populate_tables()
+    FunWatchRegistry.instance().set_system_db(deploy.database)
 
     database = deploy.database
     app_info: AppInfo = get_app_info(__file__)  # type: ignore[assignment]

--- a/data_collector/examples/captcha/solve_image/main.py
+++ b/data_collector/examples/captcha/solve_image/main.py
@@ -36,7 +36,7 @@ from data_collector.settings.captcha import CaptchaSettings
 from data_collector.settings.main import LogSettings
 from data_collector.tables.apps import AppGroups, AppParents, Apps
 from data_collector.tables.captcha import CaptchaLog, CaptchaLogError
-from data_collector.tables.deploy import Deploy
+from data_collector.tables.deploy import ExampleDeploy
 from data_collector.tables.runtime import Runtime
 from data_collector.utilities.database.main import Database
 from data_collector.utilities.fun_watch import FunWatchMixin, FunWatchRegistry, fun_watch
@@ -183,7 +183,6 @@ def _register_app(database: Database, app_info: AppInfo) -> None:
                 run_status=RunStatus.NOT_RUNNING,
                 fatal_flag=FatalFlag.NONE,
                 disable=True,
-                managed=False,
             ),
             session,
             filter_cols=["group_name", "parent_name", "app_name"],
@@ -224,9 +223,10 @@ def main() -> None:
 
     FunWatchRegistry.reset()
 
-    deploy = Deploy()
+    deploy = ExampleDeploy()
     deploy.create_tables()
     deploy.populate_tables()
+    FunWatchRegistry.instance().set_system_db(deploy.database)
 
     database = deploy.database
     app_info: AppInfo = get_app_info(__file__)  # type: ignore[assignment]

--- a/data_collector/examples/captcha/solve_recaptcha/main.py
+++ b/data_collector/examples/captcha/solve_recaptcha/main.py
@@ -36,7 +36,7 @@ from data_collector.settings.captcha import CaptchaSettings
 from data_collector.settings.main import LogSettings
 from data_collector.tables.apps import AppGroups, AppParents, Apps
 from data_collector.tables.captcha import CaptchaLog, CaptchaLogError
-from data_collector.tables.deploy import Deploy
+from data_collector.tables.deploy import ExampleDeploy
 from data_collector.tables.runtime import Runtime
 from data_collector.utilities.database.main import Database
 from data_collector.utilities.fun_watch import FunWatchMixin, FunWatchRegistry, fun_watch
@@ -183,7 +183,6 @@ def _register_app(database: Database, app_info: AppInfo) -> None:
                 run_status=RunStatus.NOT_RUNNING,
                 fatal_flag=FatalFlag.NONE,
                 disable=True,
-                managed=False,
             ),
             session,
             filter_cols=["group_name", "parent_name", "app_name"],
@@ -224,9 +223,10 @@ def main() -> None:
 
     FunWatchRegistry.reset()
 
-    deploy = Deploy()
+    deploy = ExampleDeploy()
     deploy.create_tables()
     deploy.populate_tables()
+    FunWatchRegistry.instance().set_system_db(deploy.database)
 
     database = deploy.database
     app_info: AppInfo = get_app_info(__file__)  # type: ignore[assignment]

--- a/data_collector/examples/fun_watch/01_basic_decorator.py
+++ b/data_collector/examples/fun_watch/01_basic_decorator.py
@@ -32,9 +32,9 @@ from typing import Any
 
 from sqlalchemy import select
 
-from data_collector.settings.main import LogSettings, MainDatabaseSettings
+from data_collector.settings.main import LogSettings
 from data_collector.tables.apps import AppFunctions, AppGroups, AppParents, Apps
-from data_collector.tables.deploy import Deploy
+from data_collector.tables.deploy import ExampleDeploy
 from data_collector.tables.log import FunctionLog, Logs
 from data_collector.tables.runtime import Runtime
 from data_collector.utilities.database.main import Database
@@ -164,11 +164,12 @@ def main() -> None:
     app_id = app_info["app_id"]
     runtime_id = uuid.uuid4().hex
 
-    deploy = Deploy()
+    deploy = ExampleDeploy()
     deploy.create_tables()
     deploy.populate_tables()
+    FunWatchRegistry.instance().set_system_db(deploy.database)
 
-    db = Database(MainDatabaseSettings())
+    db = deploy.database
     _seed_parent_rows(db, app_info, runtime_id)
 
     log_settings = LogSettings(log_level=10, log_error_file="error.log")

--- a/data_collector/examples/fun_watch/02_database_rows.py
+++ b/data_collector/examples/fun_watch/02_database_rows.py
@@ -33,9 +33,9 @@ from typing import Any
 
 from sqlalchemy import select
 
-from data_collector.settings.main import LogSettings, MainDatabaseSettings
+from data_collector.settings.main import LogSettings
 from data_collector.tables.apps import AppFunctions, AppGroups, AppParents, Apps
-from data_collector.tables.deploy import Deploy
+from data_collector.tables.deploy import ExampleDeploy
 from data_collector.tables.log import FunctionLog, Logs
 from data_collector.tables.runtime import Runtime
 from data_collector.utilities.database.main import Database
@@ -167,11 +167,12 @@ def main() -> None:
     runtime_child = uuid.uuid4().hex
     app_ids = [app_id_main, app_id_child]
 
-    deploy = Deploy()
+    deploy = ExampleDeploy()
     deploy.create_tables()
     deploy.populate_tables()
+    FunWatchRegistry.instance().set_system_db(deploy.database)
 
-    db = Database(MainDatabaseSettings())
+    db = deploy.database
     _seed_parent_rows(db, app_info, [
         (app_id_main, app_info["app_name"], runtime_main),
         (app_id_child, app_info["app_name"] + "_child", runtime_child),

--- a/data_collector/examples/fun_watch/03_multithreaded.py
+++ b/data_collector/examples/fun_watch/03_multithreaded.py
@@ -35,9 +35,9 @@ from typing import Any
 
 from sqlalchemy import select
 
-from data_collector.settings.main import LogSettings, MainDatabaseSettings
+from data_collector.settings.main import LogSettings
 from data_collector.tables.apps import AppFunctions, AppGroups, AppParents, Apps
-from data_collector.tables.deploy import Deploy
+from data_collector.tables.deploy import ExampleDeploy
 from data_collector.tables.log import FunctionLog, FunctionLogError, Logs
 from data_collector.tables.runtime import Runtime
 from data_collector.utilities.database.main import Database
@@ -210,11 +210,12 @@ def main() -> None:
     app_id = app_info["app_id"]
     runtime_id = uuid.uuid4().hex
 
-    deploy = Deploy()
+    deploy = ExampleDeploy()
     deploy.create_tables()
     deploy.populate_tables()
+    FunWatchRegistry.instance().set_system_db(deploy.database)
 
-    db = Database(MainDatabaseSettings())
+    db = deploy.database
     _seed_parent_rows(db, app_info, runtime_id)
 
     log_settings = LogSettings(log_level=10, log_error_file="error.log")

--- a/data_collector/examples/scraping/__main__.py
+++ b/data_collector/examples/scraping/__main__.py
@@ -17,7 +17,7 @@ import sys
 from sqlalchemy import Table
 
 from data_collector.examples.scraping import SCHEMA
-from data_collector.tables.deploy import Deploy
+from data_collector.tables.deploy import ExampleDeploy
 from data_collector.tables.shared import Base
 
 _EXAMPLES_DIR = pathlib.Path(__file__).parent
@@ -48,7 +48,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    deploy = Deploy()
+    deploy = ExampleDeploy()
 
     if args.command == "create":
         deploy.create_tables(tables=_EXAMPLE_TABLES, schema=SCHEMA)

--- a/data_collector/examples/scraping/abort_blocker/main.py
+++ b/data_collector/examples/scraping/abort_blocker/main.py
@@ -31,13 +31,12 @@ from typing import Any
 from sqlalchemy import select
 
 from data_collector.enums import ErrorCategory, FatalFlag, RunStatus
-from data_collector.examples.scraping import SCHEMA
 from data_collector.examples.scraping.books.parser import Parser
 from data_collector.scraping import DEFAULT_CATEGORY_THRESHOLDS, ThreadedScraper
 from data_collector.scraping.base import update_app_status
 from data_collector.settings.main import LogSettings
 from data_collector.tables.apps import AppGroups, AppParents, Apps
-from data_collector.tables.deploy import Deploy
+from data_collector.tables.deploy import ExampleDeploy
 from data_collector.tables.runtime import Runtime
 from data_collector.utilities.database.main import Database
 from data_collector.utilities.fun_watch import FunWatchRegistry, fun_watch
@@ -161,7 +160,6 @@ def _register_app(database: Database, app_info: AppInfo) -> None:
                 run_status=RunStatus.NOT_RUNNING,
                 fatal_flag=FatalFlag.NONE,
                 disable=True,
-                managed=False,
             ),
             session,
             filter_cols=["group_name", "parent_name", "app_name"],
@@ -202,10 +200,11 @@ def main() -> None:
 
     FunWatchRegistry.reset()
 
-    deploy = Deploy()
-    deploy.database.ensure_schema(SCHEMA)
+    # Deploy all tables into dc_example schema (non-destructive) + codebook seed data
+    deploy = ExampleDeploy()
     deploy.create_tables()
     deploy.populate_tables()
+    FunWatchRegistry.instance().set_system_db(deploy.database)
 
     database = deploy.database
     app_info: AppInfo = get_app_info(__file__)  # type: ignore[assignment]

--- a/data_collector/examples/scraping/abort_http/main.py
+++ b/data_collector/examples/scraping/abort_http/main.py
@@ -30,12 +30,11 @@ from typing import Any
 from sqlalchemy import select
 
 from data_collector.enums import ErrorCategory, FatalFlag, RunStatus
-from data_collector.examples.scraping import SCHEMA
 from data_collector.examples.scraping.books.parser import Parser
 from data_collector.scraping.base import BaseScraper, CategoryThreshold, update_app_status
 from data_collector.settings.main import LogSettings
 from data_collector.tables.apps import AppGroups, AppParents, Apps
-from data_collector.tables.deploy import Deploy
+from data_collector.tables.deploy import ExampleDeploy
 from data_collector.tables.runtime import Runtime
 from data_collector.utilities.database.main import Database
 from data_collector.utilities.fun_watch import FunWatchRegistry, fun_watch
@@ -157,7 +156,6 @@ def _register_app(database: Database, app_info: AppInfo) -> None:
                 run_status=RunStatus.NOT_RUNNING,
                 fatal_flag=FatalFlag.NONE,
                 disable=True,
-                managed=False,
             ),
             session,
             filter_cols=["group_name", "parent_name", "app_name"],
@@ -198,10 +196,11 @@ def main() -> None:
 
     FunWatchRegistry.reset()
 
-    deploy = Deploy()
-    deploy.database.ensure_schema(SCHEMA)
+    # Deploy all tables into dc_example schema (non-destructive) + codebook seed data
+    deploy = ExampleDeploy()
     deploy.create_tables()
     deploy.populate_tables()
+    FunWatchRegistry.instance().set_system_db(deploy.database)
 
     database = deploy.database
     app_info: AppInfo = get_app_info(__file__)  # type: ignore[assignment]

--- a/data_collector/examples/scraping/books/main.py
+++ b/data_collector/examples/scraping/books/main.py
@@ -27,13 +27,12 @@ from typing import Any
 from sqlalchemy import select
 
 from data_collector.enums import FatalFlag, RunStatus
-from data_collector.examples.scraping import SCHEMA
 from data_collector.examples.scraping.books.parser import Parser
 from data_collector.scraping import DEFAULT_CATEGORY_THRESHOLDS, BaseScraper
 from data_collector.scraping.base import update_app_status
 from data_collector.settings.main import LogSettings
 from data_collector.tables.apps import AppGroups, AppParents, Apps
-from data_collector.tables.deploy import Deploy
+from data_collector.tables.deploy import ExampleDeploy
 from data_collector.tables.runtime import Runtime
 from data_collector.utilities.database.main import Database
 from data_collector.utilities.fun_watch import FunWatchRegistry, fun_watch
@@ -124,7 +123,6 @@ def _register_app(database: Database, app_info: AppInfo) -> None:
                 run_status=RunStatus.NOT_RUNNING,
                 fatal_flag=FatalFlag.NONE,
                 disable=True,
-                managed=False,
             ),
             session,
             filter_cols=["group_name", "parent_name", "app_name"],
@@ -165,11 +163,11 @@ def main() -> None:
 
     FunWatchRegistry.reset()
 
-    # Ensure app schema exists, then deploy all tables (non-destructive) + codebook seed data
-    deploy = Deploy()
-    deploy.database.ensure_schema(SCHEMA)
+    # Deploy all tables into dc_example schema (non-destructive) + codebook seed data
+    deploy = ExampleDeploy()
     deploy.create_tables()
     deploy.populate_tables()
+    FunWatchRegistry.instance().set_system_db(deploy.database)
 
     database = deploy.database
     app_info: AppInfo = get_app_info(__file__)  # type: ignore[assignment]

--- a/data_collector/examples/scraping/posts/main.py
+++ b/data_collector/examples/scraping/posts/main.py
@@ -28,13 +28,12 @@ from typing import Any
 from sqlalchemy import select
 
 from data_collector.enums import FatalFlag, RunStatus
-from data_collector.examples.scraping import SCHEMA
 from data_collector.examples.scraping.posts.parser import Parser
 from data_collector.scraping import DEFAULT_CATEGORY_THRESHOLDS, AsyncScraper
 from data_collector.scraping.base import update_app_status
 from data_collector.settings.main import LogSettings
 from data_collector.tables.apps import AppGroups, AppParents, Apps
-from data_collector.tables.deploy import Deploy
+from data_collector.tables.deploy import ExampleDeploy
 from data_collector.tables.runtime import Runtime
 from data_collector.utilities.database.main import Database
 from data_collector.utilities.fun_watch import FunWatchRegistry, fun_watch
@@ -124,7 +123,6 @@ def _register_app(database: Database, app_info: AppInfo) -> None:
                 run_status=RunStatus.NOT_RUNNING,
                 fatal_flag=FatalFlag.NONE,
                 disable=True,
-                managed=False,
             ),
             session,
             filter_cols=["group_name", "parent_name", "app_name"],
@@ -165,11 +163,11 @@ async def main() -> None:
 
     FunWatchRegistry.reset()
 
-    # Ensure app schema exists, then deploy all tables (non-destructive) + codebook seed data
-    deploy = Deploy()
-    deploy.database.ensure_schema(SCHEMA)
+    # Deploy all tables into dc_example schema (non-destructive) + codebook seed data
+    deploy = ExampleDeploy()
     deploy.create_tables()
     deploy.populate_tables()
+    FunWatchRegistry.instance().set_system_db(deploy.database)
 
     database = deploy.database
     app_info: AppInfo = get_app_info(__file__)  # type: ignore[assignment]

--- a/data_collector/examples/scraping/proxy_single/main.py
+++ b/data_collector/examples/scraping/proxy_single/main.py
@@ -29,7 +29,6 @@ from typing import Any
 from sqlalchemy import select
 
 from data_collector.enums import ErrorCategory, FatalFlag, RunStatus
-from data_collector.examples.scraping import SCHEMA
 from data_collector.examples.scraping.books.parser import Parser
 from data_collector.examples.scraping.books.tables import ExampleBook as ExampleBook
 from data_collector.proxy import BrightDataProvider, ProxyManager
@@ -39,7 +38,7 @@ from data_collector.scraping.base import update_app_status
 from data_collector.settings.main import LogSettings
 from data_collector.settings.proxy import ProxySettings
 from data_collector.tables.apps import AppGroups, AppParents, Apps
-from data_collector.tables.deploy import Deploy
+from data_collector.tables.deploy import ExampleDeploy
 from data_collector.tables.runtime import Runtime
 from data_collector.utilities.database.main import Database
 from data_collector.utilities.fun_watch import FunWatchRegistry, fun_watch
@@ -158,7 +157,6 @@ def _register_app(database: Database, app_info: AppInfo) -> None:
                 run_status=RunStatus.NOT_RUNNING,
                 fatal_flag=FatalFlag.NONE,
                 disable=True,
-                managed=False,
             ),
             session,
             filter_cols=["group_name", "parent_name", "app_name"],
@@ -199,10 +197,11 @@ def main() -> None:
 
     FunWatchRegistry.reset()
 
-    deploy = Deploy()
-    deploy.database.ensure_schema(SCHEMA)
+    # Deploy all tables into dc_example schema (non-destructive) + codebook seed data
+    deploy = ExampleDeploy()
     deploy.create_tables()
     deploy.populate_tables()
+    FunWatchRegistry.instance().set_system_db(deploy.database)
 
     database = deploy.database
     app_info: AppInfo = get_app_info(__file__)  # type: ignore[assignment]

--- a/data_collector/examples/scraping/proxy_threaded/main.py
+++ b/data_collector/examples/scraping/proxy_threaded/main.py
@@ -37,7 +37,6 @@ from typing import Any
 from sqlalchemy import select
 
 from data_collector.enums import ErrorCategory, FatalFlag, RunStatus
-from data_collector.examples.scraping import SCHEMA
 from data_collector.examples.scraping.quotes_authors.parser import Parser
 from data_collector.examples.scraping.quotes_authors.tables import ExampleQuoteAuthor as ExampleQuoteAuthor
 from data_collector.proxy import BrightDataProvider, ProxyManager
@@ -46,7 +45,7 @@ from data_collector.scraping.base import update_app_status
 from data_collector.settings.main import LogSettings
 from data_collector.settings.proxy import ProxySettings
 from data_collector.tables.apps import AppGroups, AppParents, Apps
-from data_collector.tables.deploy import Deploy
+from data_collector.tables.deploy import ExampleDeploy
 from data_collector.tables.runtime import Runtime
 from data_collector.utilities.database.main import Database
 from data_collector.utilities.fun_watch import FunWatchRegistry, fun_watch
@@ -181,7 +180,6 @@ def _register_app(database: Database, app_info: AppInfo) -> None:
                 run_status=RunStatus.NOT_RUNNING,
                 fatal_flag=FatalFlag.NONE,
                 disable=True,
-                managed=False,
             ),
             session,
             filter_cols=["group_name", "parent_name", "app_name"],
@@ -222,10 +220,11 @@ def main() -> None:
 
     FunWatchRegistry.reset()
 
-    deploy = Deploy()
-    deploy.database.ensure_schema(SCHEMA)
+    # Deploy all tables into dc_example schema (non-destructive) + codebook seed data
+    deploy = ExampleDeploy()
     deploy.create_tables()
     deploy.populate_tables()
+    FunWatchRegistry.instance().set_system_db(deploy.database)
 
     database = deploy.database
     app_info: AppInfo = get_app_info(__file__)  # type: ignore[assignment]

--- a/data_collector/examples/scraping/quotes/main.py
+++ b/data_collector/examples/scraping/quotes/main.py
@@ -27,13 +27,12 @@ from typing import Any
 from sqlalchemy import select
 
 from data_collector.enums import FatalFlag, RunStatus
-from data_collector.examples.scraping import SCHEMA
 from data_collector.examples.scraping.quotes.parser import Parser
 from data_collector.scraping import DEFAULT_CATEGORY_THRESHOLDS, ThreadedScraper
 from data_collector.scraping.base import update_app_status
 from data_collector.settings.main import LogSettings
 from data_collector.tables.apps import AppGroups, AppParents, Apps
-from data_collector.tables.deploy import Deploy
+from data_collector.tables.deploy import ExampleDeploy
 from data_collector.tables.runtime import Runtime
 from data_collector.utilities.database.main import Database
 from data_collector.utilities.fun_watch import FunWatchRegistry, fun_watch
@@ -132,7 +131,6 @@ def _register_app(database: Database, app_info: AppInfo) -> None:
                 run_status=RunStatus.NOT_RUNNING,
                 fatal_flag=FatalFlag.NONE,
                 disable=True,
-                managed=False,
             ),
             session,
             filter_cols=["group_name", "parent_name", "app_name"],
@@ -173,11 +171,11 @@ def main() -> None:
 
     FunWatchRegistry.reset()
 
-    # Ensure app schema exists, then deploy all tables (non-destructive) + codebook seed data
-    deploy = Deploy()
-    deploy.database.ensure_schema(SCHEMA)
+    # Deploy all tables into dc_example schema (non-destructive) + codebook seed data
+    deploy = ExampleDeploy()
     deploy.create_tables()
     deploy.populate_tables()
+    FunWatchRegistry.instance().set_system_db(deploy.database)
 
     database = deploy.database
     app_info: AppInfo = get_app_info(__file__)  # type: ignore[assignment]

--- a/data_collector/examples/scraping/quotes_authors/main.py
+++ b/data_collector/examples/scraping/quotes_authors/main.py
@@ -29,14 +29,13 @@ from typing import Any
 from sqlalchemy import select
 
 from data_collector.enums import FatalFlag, RunStatus
-from data_collector.examples.scraping import SCHEMA
 from data_collector.examples.scraping.quotes_authors.parser import Parser
 from data_collector.examples.scraping.quotes_authors.tables import ExampleQuoteAuthor
 from data_collector.scraping import DEFAULT_CATEGORY_THRESHOLDS, ThreadedScraper
 from data_collector.scraping.base import update_app_status
 from data_collector.settings.main import LogSettings
 from data_collector.tables.apps import AppGroups, AppParents, Apps
-from data_collector.tables.deploy import Deploy
+from data_collector.tables.deploy import ExampleDeploy
 from data_collector.tables.runtime import Runtime
 from data_collector.utilities.database.main import Database
 from data_collector.utilities.fun_watch import FunWatchRegistry, fun_watch
@@ -209,7 +208,6 @@ def _register_app(database: Database, app_info: AppInfo) -> None:
                 run_status=RunStatus.NOT_RUNNING,
                 fatal_flag=FatalFlag.NONE,
                 disable=True,
-                managed=False,
             ),
             session,
             filter_cols=["group_name", "parent_name", "app_name"],
@@ -250,10 +248,11 @@ def main() -> None:
 
     FunWatchRegistry.reset()
 
-    deploy = Deploy()
-    deploy.database.ensure_schema(SCHEMA)
+    # Deploy all tables into dc_example schema (non-destructive) + codebook seed data
+    deploy = ExampleDeploy()
     deploy.create_tables()
     deploy.populate_tables()
+    FunWatchRegistry.instance().set_system_db(deploy.database)
 
     database = deploy.database
     app_info: AppInfo = get_app_info(__file__)  # type: ignore[assignment]

--- a/data_collector/examples/storage/01_local_storage.py
+++ b/data_collector/examples/storage/01_local_storage.py
@@ -27,11 +27,10 @@ from pathlib import Path
 from sqlalchemy import select
 
 from data_collector.enums.storage import FileRetention
-from data_collector.settings.main import MainDatabaseSettings
 from data_collector.settings.storage import StorageSettings
 from data_collector.storage.manager import StorageManager
 from data_collector.tables.apps import AppGroups, AppParents, Apps
-from data_collector.tables.deploy import Deploy
+from data_collector.tables.deploy import ExampleDeploy
 from data_collector.tables.runtime import Runtime
 from data_collector.tables.storage import StoredFile
 from data_collector.utilities.database.main import Database
@@ -101,11 +100,11 @@ def main() -> None:
     assert isinstance(app_info, dict)
     runtime_id = uuid.uuid4().hex
 
-    deploy = Deploy()
+    deploy = ExampleDeploy()
     deploy.create_tables()
     deploy.populate_tables()
 
-    database = Database(MainDatabaseSettings())
+    database = deploy.database
     _seed_parent_rows(database, app_info, runtime_id)
 
     settings = StorageSettings()

--- a/data_collector/examples/storage/02_multi_backend.py
+++ b/data_collector/examples/storage/02_multi_backend.py
@@ -28,11 +28,10 @@ from pathlib import Path
 from sqlalchemy import select
 
 from data_collector.enums.storage import FileRetention
-from data_collector.settings.main import MainDatabaseSettings
 from data_collector.settings.storage import StorageSettings
 from data_collector.storage.manager import StorageManager
 from data_collector.tables.apps import AppGroups, AppParents, Apps
-from data_collector.tables.deploy import Deploy
+from data_collector.tables.deploy import ExampleDeploy
 from data_collector.tables.runtime import Runtime
 from data_collector.tables.storage import StorageBackend
 from data_collector.utilities.database.main import Database
@@ -111,11 +110,11 @@ def main() -> None:
     assert isinstance(app_info, dict)
     runtime_id = uuid.uuid4().hex
 
-    deploy = Deploy()
+    deploy = ExampleDeploy()
     deploy.create_tables()
     deploy.populate_tables()
 
-    database = Database(MainDatabaseSettings())
+    database = deploy.database
     _seed_parent_rows(database, app_info, runtime_id)
 
     settings = StorageSettings()

--- a/data_collector/examples/storage/03_retention.py
+++ b/data_collector/examples/storage/03_retention.py
@@ -25,11 +25,10 @@ from datetime import UTC, datetime
 from sqlalchemy import select
 
 from data_collector.enums.storage import FileRetention
-from data_collector.settings.main import MainDatabaseSettings
 from data_collector.settings.storage import StorageSettings
 from data_collector.storage.manager import StorageManager
 from data_collector.tables.apps import AppGroups, AppParents, Apps
-from data_collector.tables.deploy import Deploy
+from data_collector.tables.deploy import ExampleDeploy
 from data_collector.tables.runtime import Runtime
 from data_collector.tables.storage import CodebookFileRetention
 from data_collector.utilities.database.main import Database
@@ -125,11 +124,11 @@ def main() -> None:
     assert isinstance(app_info, dict)
     runtime_id = uuid.uuid4().hex
 
-    deploy = Deploy()
+    deploy = ExampleDeploy()
     deploy.create_tables()
     deploy.populate_tables()
 
-    database = Database(MainDatabaseSettings())
+    database = deploy.database
     _seed_parent_rows(database, app_info, runtime_id)
 
     settings = StorageSettings()

--- a/data_collector/examples/storage/04_remote_to_local.py
+++ b/data_collector/examples/storage/04_remote_to_local.py
@@ -35,12 +35,11 @@ from pathlib import Path
 from sqlalchemy import select
 
 from data_collector.enums.storage import FileRetention
-from data_collector.settings.main import MainDatabaseSettings
 from data_collector.settings.storage import StorageSettings
 from data_collector.storage.backend import FilesystemBackend
 from data_collector.storage.manager import StorageManager
 from data_collector.tables.apps import AppGroups, AppParents, Apps
-from data_collector.tables.deploy import Deploy
+from data_collector.tables.deploy import ExampleDeploy
 from data_collector.tables.runtime import Runtime
 from data_collector.tables.storage import StorageBackend
 from data_collector.utilities.database.main import Database
@@ -119,11 +118,11 @@ def main() -> None:
     assert isinstance(app_info, dict)
     runtime_id = uuid.uuid4().hex
 
-    deploy = Deploy()
+    deploy = ExampleDeploy()
     deploy.create_tables()
     deploy.populate_tables()
 
-    database = Database(MainDatabaseSettings())
+    database = deploy.database
     _seed_parent_rows(database, app_info, runtime_id)
 
     settings = StorageSettings()

--- a/data_collector/examples/watchservice/01_stress_test.py
+++ b/data_collector/examples/watchservice/01_stress_test.py
@@ -34,7 +34,7 @@ from data_collector.messaging.watchservice import IngestEventHandler, Root, Watc
 from data_collector.settings.main import LogSettings
 from data_collector.settings.watchservice import WatchServiceSettings
 from data_collector.tables.apps import AppGroups, AppParents, Apps
-from data_collector.tables.deploy import Deploy
+from data_collector.tables.deploy import ExampleDeploy
 from data_collector.tables.pipeline import Events, WatchRoots
 from data_collector.tables.runtime import Runtime
 from data_collector.utilities.database.main import Database
@@ -279,7 +279,7 @@ def main() -> None:
 
     # ---- Step 1: Deploy tables ----
     print("[1/6] Deploying tables (recreate) ...")
-    deploy = Deploy()
+    deploy = ExampleDeploy()
     deploy.recreate_tables()
     deploy.populate_tables()
     database = deploy.database

--- a/data_collector/examples/watchservice/02_crash_recovery.py
+++ b/data_collector/examples/watchservice/02_crash_recovery.py
@@ -40,7 +40,7 @@ from data_collector.messaging.watchservice import IngestEventHandler, Root, Watc
 from data_collector.settings.main import LogSettings
 from data_collector.settings.watchservice import WatchServiceSettings
 from data_collector.tables.apps import AppGroups, AppParents, Apps
-from data_collector.tables.deploy import Deploy
+from data_collector.tables.deploy import ExampleDeploy
 from data_collector.tables.pipeline import Events, WatchRoots
 from data_collector.tables.runtime import Runtime
 from data_collector.utilities.database.main import Database
@@ -340,7 +340,7 @@ def main() -> None:
 
     # ---- Step 1: Deploy tables ----
     print("[1/8] Deploying tables (recreate) ...")
-    deploy = Deploy()
+    deploy = ExampleDeploy()
     deploy.recreate_tables()
     deploy.populate_tables()
     database = deploy.database

--- a/data_collector/tables/deploy.py
+++ b/data_collector/tables/deploy.py
@@ -468,3 +468,48 @@ class Deploy:
         except http_requests.RequestException as exc:
             self.logger.error("Failed to create Splunk sourcetype '%s': %s", sourcetype, exc)
             return False
+
+
+EXAMPLE_SCHEMA = "dc_example"
+
+
+class ExampleDeploy(Deploy):
+    """Deploy variant that isolates all tables into the ``dc_example`` schema.
+
+    Uses SQLAlchemy ``schema_translate_map`` to redirect framework tables (schema=None)
+    and example data tables (schema="scraping") into ``dc_example`` without modifying ORM
+    model definitions. Production ``Deploy`` remains untouched.
+    """
+
+    def __init__(self) -> None:
+        self.database = Database(
+            MainDatabaseSettings(),
+            schema_translate_map={None: EXAMPLE_SCHEMA, "scraping": EXAMPLE_SCHEMA},
+        )
+        self.logger = logging.getLogger(__name__)
+        self.logger.setLevel(logging.DEBUG)
+
+    def create_tables(
+        self,
+        tables: Sequence[Table] | None = None,
+        schema: str | None = None,
+    ) -> None:
+        """Create tables in the dc_example schema.
+
+        Args:
+            tables: Specific tables to create. None = all Base metadata tables.
+            schema: Ignored. The dc_example schema is always used.
+        """
+        self.database.ensure_schema(EXAMPLE_SCHEMA)
+        Base.metadata.create_all(self.database.engine, tables=tables)
+
+    def drop_tables(
+        self,
+        tables: Sequence[Table] | None = None,
+    ) -> None:
+        """Drop tables from the dc_example schema.
+
+        Args:
+            tables: Specific tables to drop. None = all Base metadata tables.
+        """
+        Base.metadata.drop_all(self.database.engine, tables=tables)

--- a/data_collector/utilities/database/main.py
+++ b/data_collector/utilities/database/main.py
@@ -243,7 +243,13 @@ def database_classes(db_type: DatabaseType) -> type[BaseDBConnector]:
 
 
 class Database:
-    def __init__(self, settings: DatabaseSettings, app_id: str | None = None, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        settings: DatabaseSettings,
+        app_id: str | None = None,
+        schema_translate_map: dict[str | None, str | None] | None = None,
+        **kwargs: Any,
+    ) -> None:
         """Initialize a database interface with SQLAlchemy engine and optional object mapping.
 
         Args:
@@ -251,6 +257,10 @@ class Database:
             app_id: Hashed application identifier for dependency tracking. Required when
                 settings.map_objects is True. Used to register database object dependencies
                 (tables, views, routines) in AppDbObjects for analytics and orchestration.
+            schema_translate_map: Optional schema name translation map applied to the engine.
+                Redirects SQL schema references at the connection level without modifying ORM
+                model definitions. Example: ``{None: "dc_example"}`` routes all tables with no
+                explicit schema from the default schema (public/dbo) into ``dc_example``.
             **kwargs: Additional keyword arguments passed to SQLAlchemy's create_engine().
         """
         self.settings = settings
@@ -258,7 +268,10 @@ class Database:
         self.app_id: str | None = app_id
         self.logger: logging.Logger = logging.getLogger(__name__)
         self._system_db: Database | None = None
+        self._schema_translate_map = schema_translate_map
         self.engine: Engine = self.engine_construct(**kwargs)
+        if schema_translate_map is not None:
+            self.engine = self.engine.execution_options(schema_translate_map=schema_translate_map)
 
     def engine_construct(self, **kwargs: Any) -> Engine:
         """Construct and return a SQLAlchemy Engine.
@@ -631,7 +644,7 @@ class Database:
     def _get_system_db(self) -> "Database":
         """Returns a cached Database instance connected to the main system database."""
         if self._system_db is None:
-            self._system_db = Database(MainDatabaseSettings())
+            self._system_db = Database(MainDatabaseSettings(), schema_translate_map=self._schema_translate_map)
         return self._system_db
 
     def _track_models_from_objects(self, objects: list[Any] | tuple[Any, ...]) -> set[type[Any]]:

--- a/data_collector/utilities/fun_watch.py
+++ b/data_collector/utilities/fun_watch.py
@@ -230,6 +230,18 @@ class FunWatchRegistry:
         with cls._instance_lock:
             cls._instance = None
 
+    def set_system_db(self, database: Database) -> None:
+        """Override the lazily-created system database with an externally managed instance.
+
+        Used by example apps to redirect system table writes (AppFunctions, FunctionLog)
+        to an isolated schema via ``schema_translate_map``.
+
+        Args:
+            database: A Database instance (typically with schema_translate_map applied).
+        """
+        with self._db_lock:
+            self._system_db = database
+
     def _get_system_db(self) -> Database:
         """Return a lazily-created Database for system table writes."""
         if self._system_db is None:

--- a/tests/unit/tables/test_example_deploy.py
+++ b/tests/unit/tables/test_example_deploy.py
@@ -1,0 +1,211 @@
+import threading
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from data_collector.tables.deploy import EXAMPLE_SCHEMA, ExampleDeploy
+from data_collector.utilities.database.main import Database
+from data_collector.utilities.fun_watch import FunWatchRegistry
+
+_DEPLOY_MODULE = "data_collector.tables.deploy"
+_DB_MODULE = "data_collector.utilities.database.main"
+
+
+# ---------------------------------------------------------------------------
+# ExampleDeploy tests
+# ---------------------------------------------------------------------------
+
+
+@patch(f"{_DEPLOY_MODULE}.Database")
+@patch(f"{_DEPLOY_MODULE}.MainDatabaseSettings")
+def test_example_deploy_passes_schema_translate_map_to_database(
+    _mock_settings: MagicMock,
+    mock_db_cls: MagicMock,
+) -> None:
+    ExampleDeploy()
+    _, kwargs = mock_db_cls.call_args
+    assert kwargs["schema_translate_map"] == {None: EXAMPLE_SCHEMA, "scraping": EXAMPLE_SCHEMA}
+
+
+@patch(f"{_DEPLOY_MODULE}.Database")
+@patch(f"{_DEPLOY_MODULE}.MainDatabaseSettings")
+def test_example_deploy_create_tables_ensures_dc_example_schema(
+    _mock_settings: MagicMock,
+    mock_db_cls: MagicMock,
+) -> None:
+    mock_db = mock_db_cls.return_value
+    deploy = ExampleDeploy()
+
+    with patch(f"{_DEPLOY_MODULE}.Base") as mock_base:
+        deploy.create_tables()
+        mock_db.ensure_schema.assert_called_once_with(EXAMPLE_SCHEMA)
+        mock_base.metadata.create_all.assert_called_once_with(mock_db.engine, tables=None)
+
+
+@patch(f"{_DEPLOY_MODULE}.Database")
+@patch(f"{_DEPLOY_MODULE}.MainDatabaseSettings")
+def test_example_deploy_create_tables_with_specific_tables(
+    _mock_settings: MagicMock,
+    mock_db_cls: MagicMock,
+) -> None:
+    mock_db = mock_db_cls.return_value
+    deploy = ExampleDeploy()
+    fake_table = MagicMock()
+
+    with patch(f"{_DEPLOY_MODULE}.Base") as mock_base:
+        deploy.create_tables(tables=[fake_table])
+        mock_db.ensure_schema.assert_called_once_with(EXAMPLE_SCHEMA)
+        mock_base.metadata.create_all.assert_called_once_with(mock_db.engine, tables=[fake_table])
+
+
+@patch(f"{_DEPLOY_MODULE}.Database")
+@patch(f"{_DEPLOY_MODULE}.MainDatabaseSettings")
+def test_example_deploy_drop_tables_uses_translated_engine(
+    _mock_settings: MagicMock,
+    mock_db_cls: MagicMock,
+) -> None:
+    deploy = ExampleDeploy()
+
+    with patch(f"{_DEPLOY_MODULE}.Base") as mock_base:
+        deploy.drop_tables()
+        mock_base.metadata.drop_all.assert_called_once_with(mock_db_cls.return_value.engine, tables=None)
+
+
+@patch(f"{_DEPLOY_MODULE}.Database")
+@patch(f"{_DEPLOY_MODULE}.MainDatabaseSettings")
+def test_example_deploy_recreate_calls_drop_then_create(
+    _mock_settings: MagicMock,
+    mock_db_cls: MagicMock,
+) -> None:
+    mock_db = mock_db_cls.return_value
+    deploy = ExampleDeploy()
+
+    with patch(f"{_DEPLOY_MODULE}.Base") as mock_base:
+        deploy.recreate_tables()
+        mock_base.metadata.drop_all.assert_called_once_with(mock_db.engine, tables=None)
+        mock_db.ensure_schema.assert_called_once_with(EXAMPLE_SCHEMA)
+        mock_base.metadata.create_all.assert_called_once_with(mock_db.engine, tables=None)
+
+
+@patch(f"{_DEPLOY_MODULE}.Database")
+@patch(f"{_DEPLOY_MODULE}.MainDatabaseSettings")
+def test_example_deploy_populate_inherits_from_deploy(
+    _mock_settings: MagicMock,
+    mock_db_cls: MagicMock,
+) -> None:
+    mock_db = mock_db_cls.return_value
+    mock_session = MagicMock()
+    mock_db.create_session.return_value.__enter__ = MagicMock(return_value=mock_session)
+    mock_db.create_session.return_value.__exit__ = MagicMock(return_value=False)
+
+    deploy = ExampleDeploy()
+    assert deploy.populate_tables() is True
+
+
+# ---------------------------------------------------------------------------
+# Database schema_translate_map tests
+# ---------------------------------------------------------------------------
+
+
+def _noop_init(self: Database, *_args: Any, **_kwargs: Any) -> None:
+    pass
+
+
+def test_database_stores_schema_translate_map() -> None:
+    mock_settings = MagicMock()
+    translate_map = {None: "dc_example", "scraping": "dc_example"}
+
+    with patch.object(Database, "__init__", _noop_init):
+        database = Database(mock_settings)
+
+    database._schema_translate_map = translate_map  # noqa: SLF001  # pyright: ignore[reportPrivateUsage, reportAttributeAccessIssue]
+    assert database._schema_translate_map == translate_map  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+
+
+@patch(f"{_DB_MODULE}.create_engine")
+@patch(f"{_DB_MODULE}.database_classes")
+def test_database_applies_schema_translate_map_to_engine(
+    mock_db_classes: MagicMock,
+    mock_create_engine: MagicMock,
+) -> None:
+    mock_settings = MagicMock()
+    mock_settings.database_type = MagicMock()
+    mock_engine = mock_create_engine.return_value
+    translate_map: dict[str | None, str | None] = {None: "dc_example"}
+
+    database = Database(mock_settings, schema_translate_map=translate_map)
+
+    mock_engine.execution_options.assert_called_once_with(schema_translate_map=translate_map)
+    assert database.engine == mock_engine.execution_options.return_value
+
+
+@patch(f"{_DB_MODULE}.create_engine")
+@patch(f"{_DB_MODULE}.database_classes")
+def test_database_without_schema_translate_map_keeps_original_engine(
+    mock_db_classes: MagicMock,
+    mock_create_engine: MagicMock,
+) -> None:
+    mock_settings = MagicMock()
+    mock_settings.database_type = MagicMock()
+    mock_engine = mock_create_engine.return_value
+
+    database = Database(mock_settings)
+
+    mock_engine.execution_options.assert_not_called()
+    assert database.engine == mock_engine
+
+
+@patch(f"{_DB_MODULE}.MainDatabaseSettings")
+@patch(f"{_DB_MODULE}.create_engine")
+@patch(f"{_DB_MODULE}.database_classes")
+def test_database_propagates_schema_translate_map_to_system_db(
+    mock_db_classes: MagicMock,
+    mock_create_engine: MagicMock,
+    mock_main_settings: MagicMock,
+) -> None:
+    mock_settings = MagicMock()
+    mock_settings.database_type = MagicMock()
+    translate_map: dict[str | None, str | None] = {None: "dc_example"}
+
+    database = Database(mock_settings, schema_translate_map=translate_map)
+    system_db = database._get_system_db()  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+
+    assert system_db._schema_translate_map == translate_map  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+
+
+# ---------------------------------------------------------------------------
+# FunWatchRegistry.set_system_db tests
+# ---------------------------------------------------------------------------
+
+
+def test_fun_watch_registry_set_system_db_overrides_lazy_instance() -> None:
+    FunWatchRegistry.reset()
+    registry = FunWatchRegistry.instance()
+    mock_database = MagicMock(spec=Database)
+
+    registry.set_system_db(mock_database)
+
+    assert registry._system_db is mock_database  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    FunWatchRegistry.reset()
+
+
+def test_fun_watch_registry_set_system_db_is_thread_safe() -> None:
+    FunWatchRegistry.reset()
+    registry = FunWatchRegistry.instance()
+    mock_database = MagicMock(spec=Database)
+    errors: list[Exception] = []
+
+    def set_db() -> None:
+        try:
+            registry.set_system_db(mock_database)
+        except Exception as exception:
+            errors.append(exception)
+
+    threads = [threading.Thread(target=set_db) for _ in range(10)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert not errors
+    assert registry._system_db is mock_database  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    FunWatchRegistry.reset()


### PR DESCRIPTION
## Work Package
N/A -- cross-cutting infrastructure improvement (not tied to a specific WP)

## Summary
- Example apps previously deployed all framework tables into the production schema (public/dbo), risking data corruption or loss if `recreate_tables()` was called against a production database
- Introduced `ExampleDeploy` subclass using SQLAlchemy `schema_translate_map` to redirect all DDL and DML to `dc_example` schema without modifying any ORM model definitions
- Added `schema_translate_map` parameter to `Database.__init__` with propagation to `_get_system_db()` for dependency tracking isolation
- Added `FunWatchRegistry.set_system_db()` for injecting schema-translated DB into the singleton
- Fixed pre-existing `managed=False` bug in 11 examples (`Apps.managed` was renamed to `Apps.app_type` in a prior PR but examples were not updated)

## Changes
- `data_collector/utilities/database/main.py` -- add `schema_translate_map` parameter to `Database.__init__`, propagate to `_get_system_db()`
- `data_collector/tables/deploy.py` -- add `EXAMPLE_SCHEMA` constant and `ExampleDeploy` subclass
- `data_collector/utilities/fun_watch.py` -- add `FunWatchRegistry.set_system_db()` method
- `data_collector/examples/scraping/*/main.py` (8 files) -- swap `Deploy` to `ExampleDeploy`, remove `ensure_schema(SCHEMA)`, add `set_system_db`, remove `managed=False`
- `data_collector/examples/scraping/__main__.py` -- swap `Deploy` to `ExampleDeploy`
- `data_collector/examples/fun_watch/*.py` (3 files) -- swap `Deploy` to `ExampleDeploy`, replace `Database(MainDatabaseSettings())` with `deploy.database`, add `set_system_db`
- `data_collector/examples/captcha/*/main.py` (3 files) -- swap `Deploy` to `ExampleDeploy`, add `set_system_db`, remove `managed=False`
- `data_collector/examples/storage/*.py` (4 files) -- swap `Deploy` to `ExampleDeploy`, replace `Database(MainDatabaseSettings())` with `deploy.database`
- `data_collector/examples/watchservice/*.py` (2 files) -- swap `Deploy` to `ExampleDeploy` (keeps `recreate_tables()` which now safely targets `dc_example`)
- `tests/unit/tables/test_example_deploy.py` -- 12 new tests covering `ExampleDeploy`, `schema_translate_map` propagation, `set_system_db` thread safety

## Testing
- `ruff check` -- 0 new errors
- `pyright` -- 0 new errors (5 pre-existing in storage examples, unrelated)
- `pytest tests/unit tests/quality` -- 1382 passed (including 12 new tests)
- Integration verification against PostgreSQL: deployed production tables in `public`, ran books example, confirmed 0 rows leaked to `public` operational tables, all data correctly in `dc_example` (100 books, 14 logs, 8 function_log, 1 runtime, 4 app_functions, 4 app_db_objects, codebooks seeded independently)

## Related
- `REVIEW.md` -- 7-phase self-review protocol followed
- `docs/51. contributing.md` -- PR process

Generated with [Claude Code](https://claude.com/claude-code)