### PR TITLE
feat: add PDF/OCR processing package (WP-14)

### DIFF
--- a/data_collector/enums/__init__.py
+++ b/data_collector/enums/__init__.py
@@ -7,6 +7,7 @@ from data_collector.enums.hashing import UnicodeForm
 from data_collector.enums.logging import LogLevel
 from data_collector.enums.notifications import AlertSeverity
 from data_collector.enums.pipeline import PipelineStage, PipelineStatus
+from data_collector.enums.processing import DocumentType, PdfDataType
 from data_collector.enums.runtime import AppType, FatalFlag, RunStatus, RuntimeExitCode
 from data_collector.enums.scraping import ErrorCategory
 from data_collector.enums.storage import FileRetention
@@ -19,6 +20,8 @@ __all__ = [
     "CmdFlag",
     "CmdName",
     "DbObjectType",
+    "DocumentType",
+    "PdfDataType",
     "ErrorCategory",
     "FatalFlag",
     "FileRetention",

--- a/data_collector/enums/processing.py
+++ b/data_collector/enums/processing.py
@@ -1,0 +1,34 @@
+"""Processing-related enums for PDF/OCR document classification."""
+
+from enum import StrEnum
+
+
+class PdfDataType(StrEnum):
+    """Classification of a PDF document's extractable content type.
+
+    Used by ``classify_pdf()`` to determine the processing path:
+
+        TEXT  -- 90%+ pages have extractable text -> pdfplumber extraction.
+        IMAGE -- Otherwise -> OCR engine extraction.
+
+    """
+
+    TEXT = "text"
+    IMAGE = "image"
+
+
+class DocumentType(StrEnum):
+    """File format classification for ingested documents.
+
+    Reserved for future use in pipeline routing and storage organization.
+    """
+
+    PDF = "pdf"
+    XML = "xml"
+    DOC = "doc"
+    DOCX = "docx"
+    XLS = "xls"
+    XLSX = "xlsx"
+    CSV = "csv"
+    HTML = "html"
+    TXT = "txt"

--- a/data_collector/processing/__init__.py
+++ b/data_collector/processing/__init__.py
@@ -1,0 +1,56 @@
+"""PDF/OCR processing package for text extraction, document classification, and OCR training."""
+
+from data_collector.processing.models import (
+    OCRError,
+    OCRResult,
+    PageText,
+    PDFClassification,
+    PDFExtractionError,
+    PDFTable,
+    PDFTables,
+    PDFText,
+    PreprocessingError,
+    ProcessingError,
+    TrainingError,
+)
+from data_collector.processing.ocr import OCREngine, PaddleOCREngine, TesseractEngine, extract_text_ocr
+from data_collector.processing.pdf import classify_pdf, extract_tables_pdfplumber, extract_text_pdfplumber
+from data_collector.processing.preprocessing import ImagePreprocessor
+from data_collector.processing.training import (
+    AccuracyResult,
+    TrainingDataset,
+    TrainingDatasetSplit,
+    TrainingSample,
+    build_character_dictionary,
+    evaluate_ocr_accuracy,
+    generate_paddleocr_config,
+)
+
+__all__ = [
+    "AccuracyResult",
+    "ImagePreprocessor",
+    "OCREngine",
+    "OCRError",
+    "OCRResult",
+    "PaddleOCREngine",
+    "PDFClassification",
+    "PDFExtractionError",
+    "PDFTable",
+    "PDFTables",
+    "PDFText",
+    "PageText",
+    "PreprocessingError",
+    "ProcessingError",
+    "TesseractEngine",
+    "TrainingDataset",
+    "TrainingDatasetSplit",
+    "TrainingError",
+    "TrainingSample",
+    "build_character_dictionary",
+    "classify_pdf",
+    "evaluate_ocr_accuracy",
+    "extract_tables_pdfplumber",
+    "extract_text_ocr",
+    "extract_text_pdfplumber",
+    "generate_paddleocr_config",
+]

--- a/data_collector/processing/models.py
+++ b/data_collector/processing/models.py
@@ -1,0 +1,131 @@
+"""Processing data models and exception types.
+
+Provides immutable result types for PDF classification, text extraction,
+table extraction, and OCR operations. Custom exception hierarchy for
+processing-specific errors.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from data_collector.enums.processing import PdfDataType
+
+
+@dataclass(frozen=True)
+class PDFClassification:
+    """Immutable result from PDF document classification.
+
+    Attributes:
+        document_type: Whether the document is text-based or image-based.
+        total_pages: Total number of pages in the PDF.
+        text_pages: Number of pages with extractable text above the threshold.
+        text_ratio: Fraction of pages classified as text (0.0-1.0).
+    """
+
+    document_type: PdfDataType
+    total_pages: int
+    text_pages: int
+    text_ratio: float
+
+
+@dataclass(frozen=True)
+class PageText:
+    """Extracted text from a single PDF page.
+
+    Attributes:
+        page_number: 1-based page number.
+        text: Extracted text content (empty string if no text found).
+    """
+
+    page_number: int
+    text: str
+
+
+@dataclass(frozen=True)
+class PDFText:
+    """Immutable result from full PDF text extraction.
+
+    Attributes:
+        pages: Per-page extracted text.
+        full_text: Concatenated text from all pages (joined by newlines).
+    """
+
+    pages: tuple[PageText, ...]
+    full_text: str
+
+
+@dataclass(frozen=True)
+class PDFTable:
+    """A single extracted table from a PDF page.
+
+    Attributes:
+        page_number: 1-based page number where the table was found.
+        rows: Table data as a tuple of tuples (header row + data rows).
+            Each inner tuple represents one row; cell values are strings or None.
+    """
+
+    page_number: int
+    rows: tuple[tuple[str | None, ...], ...]
+
+
+@dataclass(frozen=True)
+class PDFTables:
+    """Immutable result from PDF table extraction.
+
+    Attributes:
+        tables: All tables found across all pages.
+        total_tables: Number of tables found.
+    """
+
+    tables: tuple[PDFTable, ...]
+    total_tables: int
+
+
+@dataclass(frozen=True)
+class OCRResult:
+    """Immutable result from OCR text extraction.
+
+    Attributes:
+        text: Extracted text from the image or PDF page.
+        engine_name: Name of the OCR engine that produced this result.
+        preprocessed: Whether image preprocessing was applied.
+        confidence: Average confidence score (0.0-1.0) across all detected
+            text lines or words. PaddleOCR provides per-line confidence;
+            Tesseract provides per-word confidence via ``image_to_data()``.
+    """
+
+    text: str
+    engine_name: str
+    preprocessed: bool
+    confidence: float
+
+
+class ProcessingError(Exception):
+    """Base exception for all processing-related errors.
+
+    Attributes:
+        message: Human-readable error description.
+        source_path: Path to the file that caused the error, if available.
+    """
+
+    def __init__(self, message: str, source_path: str = "") -> None:
+        self.message = message
+        self.source_path = source_path
+        super().__init__(f"Processing error: {message}" + (f" (file: {source_path})" if source_path else ""))
+
+
+class PDFExtractionError(ProcessingError):
+    """Raised when PDF text or table extraction fails."""
+
+
+class OCRError(ProcessingError):
+    """Raised when OCR text extraction fails."""
+
+
+class PreprocessingError(ProcessingError):
+    """Raised when image preprocessing fails."""
+
+
+class TrainingError(ProcessingError):
+    """Raised when OCR training dataset operations fail (export, config generation, evaluation)."""

--- a/data_collector/processing/ocr.py
+++ b/data_collector/processing/ocr.py
@@ -1,0 +1,317 @@
+"""OCR engine adapter pattern with PaddleOCR as primary and Tesseract as fallback.
+
+Provides an abstract OCREngine interface with two concrete implementations:
+PaddleOCREngine (deep learning, high accuracy) and TesseractEngine (CLI-based,
+lightweight fallback). A convenience function ``extract_text_ocr`` handles file
+opening and engine selection.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytesseract
+from paddleocr import PaddleOCR
+from PIL import Image
+
+from data_collector.processing.models import OCRError, OCRResult
+from data_collector.processing.preprocessing import ImagePreprocessor
+
+logger = logging.getLogger(__name__)
+
+
+class OCREngine(ABC):
+    """Abstract OCR engine interface.
+
+    All OCR engines accept a PIL Image and return extracted text with
+    confidence. Implementations must define engine_name, _extract, and
+    _confidence.
+
+    Args:
+        preprocessor: Optional ImagePreprocessor. When provided, images
+            are preprocessed before OCR.
+    """
+
+    def __init__(self, *, preprocessor: ImagePreprocessor | None = None) -> None:
+        self._preprocessor = preprocessor
+
+    @property
+    @abstractmethod
+    def engine_name(self) -> str:
+        """Unique identifier for this OCR engine."""
+        ...
+
+    @abstractmethod
+    def _extract(self, image: Image.Image) -> str:
+        """Engine-specific text extraction.
+
+        Args:
+            image: PIL Image to extract text from.
+
+        Returns:
+            Extracted text as a single string.
+        """
+        ...
+
+    @abstractmethod
+    def _confidence(self, image: Image.Image) -> float:
+        """Engine-specific confidence score.
+
+        Args:
+            image: PIL Image that was processed (same image passed to _extract).
+
+        Returns:
+            Confidence score between 0.0 and 1.0.
+        """
+        ...
+
+    def extract_text(self, image: Image.Image, *, dpi: int | None = None) -> OCRResult:
+        """Extract text with optional preprocessing.
+
+        Runs the preprocessor if configured, then calls _extract() followed by
+        _confidence() on the same (possibly preprocessed) image.
+
+        Args:
+            image: PIL Image to process.
+            dpi: Image DPI hint passed to the preprocessor for upscale decisions.
+
+        Returns:
+            OCRResult with extracted text, engine name, preprocessing flag, and confidence.
+        """
+        preprocessed = False
+        if self._preprocessor is not None:
+            image = self._preprocessor.run(image, dpi=dpi)
+            preprocessed = True
+
+        text = self._extract(image)
+        confidence = self._confidence(image)
+        return OCRResult(text=text, engine_name=self.engine_name, preprocessed=preprocessed, confidence=confidence)
+
+
+class PaddleOCREngine(OCREngine):
+    """PaddleOCR engine -- primary OCR engine for the framework.
+
+    Uses PP-OCR deep learning models for text detection and recognition.
+    Supports 100+ languages. Superior accuracy (F1=0.938) compared to
+    Tesseract, especially on complex layouts and mixed-language documents.
+
+    Each instance creates a PaddleOCR object in ``__init__`` (loads 3 neural
+    networks, ~2-5s). The instance is reused across all ``extract_text()``
+    calls. Designed for Dramatiq worker processes where each worker creates
+    its own engine instance.
+
+    Args:
+        language: PaddleOCR language code (e.g., "en", "hr", "ch").
+        use_angle_classifier: Enable text angle classification (0/180 degree).
+        preprocessor: Optional ImagePreprocessor.
+    """
+
+    def __init__(
+        self,
+        *,
+        language: str = "en",
+        use_angle_classifier: bool = True,
+        preprocessor: ImagePreprocessor | None = None,
+    ) -> None:
+        super().__init__(preprocessor=preprocessor)
+        self._language = language
+        self._ocr = PaddleOCR(use_angle_cls=use_angle_classifier, lang=language, show_log=False)
+        self._last_result: list[Any] | None = None
+
+    @property
+    def engine_name(self) -> str:
+        """Returns the engine identifier."""
+        return "paddleocr"
+
+    def _extract(self, image: Image.Image) -> str:
+        """Extract text using PaddleOCR.
+
+        Converts the PIL Image to a numpy array, runs OCR, and joins detected
+        text lines with newlines. Caches the raw result for ``_confidence()``
+        to avoid running OCR twice.
+
+        Args:
+            image: PIL Image to extract text from.
+
+        Returns:
+            Extracted text with lines separated by newlines.
+
+        Raises:
+            OCRError: If PaddleOCR fails during extraction.
+        """
+        self._last_result = None
+        try:
+            image_array = np.array(image)
+            result = self._ocr.ocr(image_array, cls=True)
+            self._last_result = result
+
+            if not result or not result[0]:
+                return ""
+
+            lines: list[str] = []
+            for line in result[0]:
+                text = line[1][0]
+                lines.append(text)
+            return "\n".join(lines)
+        except OCRError:
+            raise
+        except Exception as error:
+            raise OCRError(f"PaddleOCR extraction failed: {error}") from error
+
+    def _confidence(self, image: Image.Image) -> float:
+        """Average per-line confidence from cached PaddleOCR result.
+
+        Uses the result cached by ``_extract()`` to avoid a redundant OCR pass.
+        Must be called after ``_extract()`` on the same image.
+
+        Args:
+            image: PIL Image (unused; confidence is derived from cached result).
+
+        Returns:
+            Average confidence between 0.0 and 1.0, or 0.0 if no text was detected.
+        """
+        if not self._last_result or not self._last_result[0]:
+            return 0.0
+
+        confidences: list[float] = [line[1][1] for line in self._last_result[0]]
+        if not confidences:
+            return 0.0
+        return sum(confidences) / len(confidences)
+
+
+class TesseractEngine(OCREngine):
+    """Tesseract OCR engine -- fallback for local dev and testing.
+
+    Requires the Tesseract binary installed on the system. pytesseract
+    is a thin wrapper that calls the Tesseract CLI.
+
+    Lighter initialization than PaddleOCR but lower accuracy (F1=0.797).
+    Works well with ``ThreadPoolExecutor`` (each call spawns a subprocess).
+
+    Prerequisites:
+        - Install Tesseract: https://github.com/tesseract-ocr/tesseract
+        - Windows: installer adds to PATH, or set ``tesseract_cmd``.
+        - Linux: ``apt install tesseract-ocr``
+
+    Args:
+        language: Tesseract language string (e.g., "eng", "eng+hrv").
+        tesseract_cmd: Path to the Tesseract executable. Empty string uses PATH lookup.
+        preprocessor: Optional ImagePreprocessor.
+    """
+
+    def __init__(
+        self,
+        *,
+        language: str = "eng",
+        tesseract_cmd: str = "",
+        preprocessor: ImagePreprocessor | None = None,
+    ) -> None:
+        super().__init__(preprocessor=preprocessor)
+        self._language = language
+        if tesseract_cmd:
+            # pytesseract uses a module-level global for the binary path. If multiple
+            # TesseractEngine instances with different tesseract_cmd values exist in the
+            # same process, the last one wins.
+            pytesseract.pytesseract.tesseract_cmd = tesseract_cmd
+
+    @property
+    def engine_name(self) -> str:
+        """Returns the engine identifier."""
+        return "tesseract"
+
+    def _extract(self, image: Image.Image) -> str:
+        """Extract text using Tesseract via pytesseract.
+
+        Args:
+            image: PIL Image to extract text from.
+
+        Returns:
+            Extracted text with leading/trailing whitespace stripped.
+
+        Raises:
+            OCRError: If the Tesseract binary is not found or extraction fails.
+        """
+        try:
+            text: str = pytesseract.image_to_string(image, lang=self._language)
+            return text.strip()
+        except pytesseract.TesseractNotFoundError as error:
+            raise OCRError(
+                "Tesseract binary not found. Install Tesseract and ensure it is on PATH, "
+                "or set DC_PROCESSING_TESSERACT_CMD."
+            ) from error
+        except pytesseract.TesseractError as error:
+            raise OCRError(f"Tesseract extraction failed: {error}") from error
+
+    def _confidence(self, image: Image.Image) -> float:
+        """Per-word confidence from Tesseract ``image_to_data()``.
+
+        Runs ``image_to_data()`` on the image and averages all per-word
+        confidence values, excluding entries with confidence -1 (non-text
+        regions). Tesseract returns confidence on a 0-100 scale; this method
+        normalizes to 0.0-1.0.
+
+        Args:
+            image: PIL Image to compute confidence for.
+
+        Returns:
+            Average confidence between 0.0 and 1.0, or 0.0 if no words were detected
+            or confidence computation fails.
+        """
+        try:
+            data = pytesseract.image_to_data(image, lang=self._language, output_type=pytesseract.Output.DICT)
+            confidences = [int(confidence) for confidence in data["conf"] if int(confidence) >= 0]
+            if not confidences:
+                return 0.0
+            return sum(confidences) / (len(confidences) * 100.0)
+        except Exception as error:
+            logger.warning(f"Failed to compute Tesseract confidence: {type(error).__name__}: {error}")
+            return 0.0
+
+
+def extract_text_ocr(
+    source: str | Path | Image.Image,
+    *,
+    engine: OCREngine | None = None,
+    dpi: int | None = None,
+) -> OCRResult:
+    """Extract text from an image or image-based PDF page using OCR.
+
+    Convenience function that opens the source, applies the OCR engine,
+    and returns structured results.
+
+    When source is a file path, opens it as a PIL Image. For multi-page
+    PDFs, convert pages to images externally and call this per page.
+
+    Args:
+        source: File path (str or Path) to an image, or a PIL Image object.
+        engine: OCR engine instance. Defaults to PaddleOCREngine().
+        dpi: Image DPI for preprocessing upscale decisions.
+
+    Returns:
+        OCRResult with extracted text, engine name, and confidence.
+
+    Raises:
+        OCRError: If the source cannot be opened or OCR fails.
+    """
+    if engine is None:
+        engine = PaddleOCREngine()
+
+    if isinstance(source, (str, Path)):
+        source_path = Path(source)
+        try:
+            with Image.open(source_path) as image:
+                logger.info(f"Running OCR with {engine.engine_name} engine")
+                return engine.extract_text(image, dpi=dpi)
+        except OCRError:
+            raise
+        except Exception as error:
+            raise OCRError(f"Cannot open image: {error}", source_path=str(source_path)) from error
+    else:
+        image = source
+
+    logger.info(f"Running OCR with {engine.engine_name} engine")
+    return engine.extract_text(image, dpi=dpi)

--- a/data_collector/processing/pdf.py
+++ b/data_collector/processing/pdf.py
@@ -1,0 +1,213 @@
+"""PDF text and table extraction via pdfplumber.
+
+Provides classification of PDF documents as text-based or image-based,
+full-text extraction, and table extraction using pdfplumber as the
+underlying engine.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pdfplumber
+
+from data_collector.enums.processing import PdfDataType
+from data_collector.processing.models import (
+    PageText,
+    PDFClassification,
+    PDFExtractionError,
+    PDFTable,
+    PDFTables,
+    PDFText,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def classify_pdf(
+    pdf_path: str | Path,
+    *,
+    threshold: float = 0.9,
+    min_text_length: int = 50,
+) -> PDFClassification:
+    """Classify a PDF as text-based or image-based.
+
+    Opens the PDF and examines each page for extractable text. If the
+    fraction of pages with meaningful text (>= min_text_length characters)
+    meets or exceeds the threshold, the document is classified as TEXT.
+
+    Args:
+        pdf_path: Path to the PDF file.
+        threshold: Minimum fraction of text pages required for TEXT classification (0.0-1.0).
+        min_text_length: Minimum stripped text length for a page to count as a text page.
+
+    Returns:
+        PDFClassification with document type, page counts, and text ratio.
+
+    Raises:
+        PDFExtractionError: If the PDF cannot be opened or read.
+    """
+    source_path = str(pdf_path)
+    try:
+        with pdfplumber.open(source_path) as pdf:
+            total_pages = len(pdf.pages)
+
+            if total_pages == 0:
+                classification = PDFClassification(
+                    document_type=PdfDataType.IMAGE,
+                    total_pages=0,
+                    text_pages=0,
+                    text_ratio=0.0,
+                )
+                logger.info(f"Classified {pdf_path}: {classification.document_type} (0 pages)")
+                return classification
+
+            text_page_count = 0
+            for page in pdf.pages:
+                extracted = page.extract_text()
+                if extracted and len(extracted.strip()) >= min_text_length:
+                    text_page_count += 1
+
+            text_ratio = text_page_count / total_pages
+            document_type = PdfDataType.TEXT if text_ratio >= threshold else PdfDataType.IMAGE
+
+            classification = PDFClassification(
+                document_type=document_type,
+                total_pages=total_pages,
+                text_pages=text_page_count,
+                text_ratio=text_ratio,
+            )
+            logger.info(
+                f"Classified {pdf_path}: {classification.document_type}"
+                f" ({text_page_count}/{total_pages} text pages, ratio={text_ratio:.2f})"
+            )
+            return classification
+
+    except PDFExtractionError:
+        raise
+    except Exception as error:
+        raise PDFExtractionError(f"Failed to classify PDF: {error}", source_path=source_path) from error
+
+
+def extract_text_pdfplumber(
+    pdf_path: str | Path,
+    *,
+    page_numbers: list[int] | None = None,
+) -> PDFText:
+    """Extract text from a PDF using pdfplumber.
+
+    Args:
+        pdf_path: Path to the PDF file.
+        page_numbers: 1-based page numbers to extract. When None, all pages are extracted.
+
+    Returns:
+        PDFText containing per-page text and concatenated full text.
+
+    Raises:
+        PDFExtractionError: If the PDF cannot be opened or page numbers are invalid.
+    """
+    source_path = str(pdf_path)
+    try:
+        with pdfplumber.open(source_path) as pdf:
+            total_pages = len(pdf.pages)
+
+            if page_numbers is not None:
+                _validate_page_numbers(page_numbers, total_pages, source_path)
+                selected_indices = [page_number - 1 for page_number in page_numbers]
+            else:
+                selected_indices = list(range(total_pages))
+
+            page_texts: list[PageText] = []
+            for index in selected_indices:
+                page = pdf.pages[index]
+                extracted = page.extract_text()
+                text = extracted if extracted else ""
+                page_texts.append(PageText(page_number=index + 1, text=text))
+
+            full_text = "\n".join(page_text.text for page_text in page_texts)
+
+            logger.info(f"Extracted text from {pdf_path}: {len(page_texts)} pages, {len(full_text)} characters")
+
+            return PDFText(pages=tuple(page_texts), full_text=full_text)
+
+    except PDFExtractionError:
+        raise
+    except Exception as error:
+        raise PDFExtractionError(f"Failed to extract text from PDF: {error}", source_path=source_path) from error
+
+
+def extract_tables_pdfplumber(
+    pdf_path: str | Path,
+    *,
+    page_numbers: list[int] | None = None,
+    table_settings: dict[str, object] | None = None,
+) -> PDFTables:
+    """Extract tables from a PDF using pdfplumber.
+
+    Args:
+        pdf_path: Path to the PDF file.
+        page_numbers: 1-based page numbers to extract tables from. When None, all pages are scanned.
+        table_settings: Settings passed directly to pdfplumber's extract_tables() method.
+
+    Returns:
+        PDFTables containing all extracted tables and a total count.
+
+    Raises:
+        PDFExtractionError: If the PDF cannot be opened or page numbers are invalid.
+    """
+    source_path = str(pdf_path)
+    try:
+        with pdfplumber.open(source_path) as pdf:
+            total_pages = len(pdf.pages)
+
+            if page_numbers is not None:
+                _validate_page_numbers(page_numbers, total_pages, source_path)
+                selected_indices = [page_number - 1 for page_number in page_numbers]
+            else:
+                selected_indices = list(range(total_pages))
+
+            extracted_tables: list[PDFTable] = []
+            for index in selected_indices:
+                page = pdf.pages[index]
+                if table_settings is not None:
+                    raw_tables = page.extract_tables(table_settings)
+                else:
+                    raw_tables = page.extract_tables()
+
+                for raw_table in raw_tables:
+                    rows = tuple(tuple(cell for cell in row) for row in raw_table)
+                    extracted_tables.append(PDFTable(page_number=index + 1, rows=rows))
+
+            result = PDFTables(tables=tuple(extracted_tables), total_tables=len(extracted_tables))
+
+            logger.info(
+                f"Extracted tables from {pdf_path}: {result.total_tables} tables"
+                f" from {len(selected_indices)} pages"
+            )
+
+            return result
+
+    except PDFExtractionError:
+        raise
+    except Exception as error:
+        raise PDFExtractionError(f"Failed to extract tables from PDF: {error}", source_path=source_path) from error
+
+
+def _validate_page_numbers(page_numbers: list[int], total_pages: int, source_path: str) -> None:
+    """Validate that all page numbers are within the valid 1-based range.
+
+    Args:
+        page_numbers: List of 1-based page numbers to validate.
+        total_pages: Total number of pages in the PDF.
+        source_path: Path to the PDF file (for error messages).
+
+    Raises:
+        PDFExtractionError: If any page number is out of range.
+    """
+    for page_number in page_numbers:
+        if page_number < 1 or page_number > total_pages:
+            raise PDFExtractionError(
+                f"Page number {page_number} is out of range (1-{total_pages})",
+                source_path=source_path,
+            )

--- a/data_collector/processing/preprocessing.py
+++ b/data_collector/processing/preprocessing.py
@@ -1,0 +1,322 @@
+"""Fixed-stage image preprocessing pipeline for OCR quality improvement.
+
+Uses OpenCV for image transformations and Pillow for format conversion.
+The pipeline executes eight stages in a fixed order, with individual stages
+toggled via constructor flags.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import cv2
+import numpy as np
+from numpy.typing import NDArray
+from PIL import Image
+
+from data_collector.processing.models import PreprocessingError
+
+logger = logging.getLogger(__name__)
+
+
+class ImagePreprocessor:
+    """Fixed-stage image preprocessing pipeline for OCR.
+
+    Pipeline stages execute in order: grayscale -> upscale -> denoise -> contrast ->
+    deskew -> binarize -> morphology -> border. Individual stages can be skipped via
+    constructor flags.
+
+    Args:
+        min_dpi: Minimum target DPI for upscaling. Images below this DPI are scaled up.
+        grayscale: Whether to convert the image to grayscale.
+        upscale: Whether to upscale low-DPI images.
+        denoise: Whether to apply non-local means denoising.
+        contrast: Whether to apply CLAHE contrast enhancement.
+        deskew: Whether to correct image skew via contour analysis.
+        binarize: Whether to apply Otsu binarization.
+        morphology: Whether to apply morphological opening and closing.
+        border: Whether to add a white border around the image.
+        clahe_clip_limit: Contrast limiting threshold for CLAHE.
+        clahe_tile_size: Size of the grid tiles for CLAHE (square grid).
+    """
+
+    def __init__(
+        self,
+        *,
+        min_dpi: int = 300,
+        grayscale: bool = True,
+        upscale: bool = True,
+        denoise: bool = True,
+        contrast: bool = True,
+        deskew: bool = True,
+        binarize: bool = True,
+        morphology: bool = True,
+        border: bool = True,
+        clahe_clip_limit: float = 2.0,
+        clahe_tile_size: int = 8,
+    ) -> None:
+        self._min_dpi = min_dpi
+        self._grayscale = grayscale
+        self._upscale = upscale
+        self._denoise = denoise
+        self._contrast = contrast
+        self._deskew = deskew
+        self._binarize = binarize
+        self._morphology = morphology
+        self._border = border
+        self._clahe_clip_limit = clahe_clip_limit
+        self._clahe_tile_size = clahe_tile_size
+
+    def run(self, image: Image.Image, dpi: int | None = None) -> Image.Image:
+        """Execute the preprocessing pipeline on a PIL Image.
+
+        Args:
+            image: Input PIL Image to preprocess.
+            dpi: Current DPI of the image. Required for upscaling; ignored if upscale is disabled.
+
+        Returns:
+            Preprocessed PIL Image ready for OCR.
+
+        Raises:
+            PreprocessingError: If any OpenCV operation fails during processing.
+        """
+        try:
+            image_array = self._pil_to_cv2(image)
+
+            if self._grayscale:
+                logger.debug(f"Preprocessing stage: grayscale (shape={image_array.shape})")
+                image_array = self._grayscale_image(image_array)
+
+            if self._upscale:
+                logger.debug(f"Preprocessing stage: upscale (dpi={dpi}, min_dpi={self._min_dpi})")
+                image_array = self._upscale_image(image_array, dpi)
+
+            if self._denoise:
+                logger.debug(f"Preprocessing stage: denoise (shape={image_array.shape})")
+                image_array = self._denoise_image(image_array)
+
+            if self._contrast:
+                logger.debug(f"Preprocessing stage: contrast (clip={self._clahe_clip_limit})")
+                image_array = self._enhance_contrast(image_array)
+
+            if self._deskew:
+                logger.debug(f"Preprocessing stage: deskew (shape={image_array.shape})")
+                image_array = self._deskew_image(image_array)
+
+            if self._binarize:
+                logger.debug(f"Preprocessing stage: binarize (shape={image_array.shape})")
+                image_array = self._binarize_image(image_array)
+
+            if self._morphology:
+                logger.debug(f"Preprocessing stage: morphology (shape={image_array.shape})")
+                image_array = self._apply_morphology(image_array)
+
+            if self._border:
+                logger.debug(f"Preprocessing stage: border (shape={image_array.shape})")
+                image_array = self._add_border(image_array)
+
+            return self._cv2_to_pil(image_array)
+
+        except PreprocessingError:
+            raise
+        except cv2.error as opencv_error:
+            raise PreprocessingError(f"OpenCV operation failed: {opencv_error}") from opencv_error
+        except Exception as unexpected_error:
+            raise PreprocessingError(f"Unexpected preprocessing failure: {unexpected_error}") from unexpected_error
+
+    def _grayscale_image(self, image_array: NDArray[np.uint8]) -> NDArray[np.uint8]:
+        """Convert image to grayscale if not already single-channel.
+
+        Args:
+            image_array: Input image as a numpy array.
+
+        Returns:
+            Single-channel grayscale image.
+        """
+        if len(image_array.shape) == 2:
+            return image_array
+        result: NDArray[np.uint8] = cv2.cvtColor(image_array, cv2.COLOR_BGR2GRAY)
+        return result
+
+    def _upscale_image(self, image_array: NDArray[np.uint8], current_dpi: int | None) -> NDArray[np.uint8]:
+        """Upscale image if current DPI is below the minimum threshold.
+
+        Args:
+            image_array: Input image as a numpy array.
+            current_dpi: Current DPI of the image. If None, upscaling is skipped.
+
+        Returns:
+            Upscaled image, or the original if no upscaling is needed.
+        """
+        if current_dpi is None or current_dpi >= self._min_dpi:
+            return image_array
+
+        scale_factor = self._min_dpi / current_dpi
+        new_width = int(image_array.shape[1] * scale_factor)
+        new_height = int(image_array.shape[0] * scale_factor)
+        logger.debug(f"Upscaling from {current_dpi} DPI to {self._min_dpi} DPI (scale={scale_factor:.2f})")
+        result: NDArray[np.uint8] = cv2.resize(image_array, (new_width, new_height), interpolation=cv2.INTER_CUBIC)
+        return result
+
+    def _denoise_image(self, image_array: NDArray[np.uint8]) -> NDArray[np.uint8]:
+        """Apply non-local means denoising.
+
+        Uses fastNlMeansDenoising for grayscale images and fastNlMeansDenoisingColored
+        for color images.
+
+        Args:
+            image_array: Input image as a numpy array.
+
+        Returns:
+            Denoised image.
+        """
+        if len(image_array.shape) == 2:
+            result: NDArray[np.uint8] = cv2.fastNlMeansDenoising(
+                image_array, None, h=10, templateWindowSize=7, searchWindowSize=21
+            )
+        else:
+            result = cv2.fastNlMeansDenoisingColored(image_array, None, h=10, hForColorComponents=10)
+        return result
+
+    def _enhance_contrast(self, image_array: NDArray[np.uint8]) -> NDArray[np.uint8]:
+        """Apply CLAHE (Contrast Limited Adaptive Histogram Equalization).
+
+        The image must be grayscale. If the image is multi-channel, it is converted
+        to grayscale first.
+
+        Args:
+            image_array: Input image as a numpy array (should be grayscale).
+
+        Returns:
+            Contrast-enhanced grayscale image.
+        """
+        if len(image_array.shape) != 2:
+            image_array = cv2.cvtColor(image_array, cv2.COLOR_BGR2GRAY)
+
+        clahe = cv2.createCLAHE(
+            clipLimit=self._clahe_clip_limit,
+            tileGridSize=(self._clahe_tile_size, self._clahe_tile_size),
+        )
+        result: NDArray[np.uint8] = clahe.apply(image_array)
+        return result
+
+    def _deskew_image(self, image_array: NDArray[np.uint8]) -> NDArray[np.uint8]:
+        """Correct image skew using contour-based angle detection.
+
+        Converts to binary via thresholding, finds the largest contour, computes
+        the minimum area rectangle angle, and rotates the image if the skew exceeds
+        0.5 degrees. Uses white fill for border pixels created by rotation.
+
+        Args:
+            image_array: Input image as a numpy array.
+
+        Returns:
+            Deskewed image, or the original if skew is negligible.
+        """
+        working_image = image_array if len(image_array.shape) == 2 else cv2.cvtColor(image_array, cv2.COLOR_BGR2GRAY)
+
+        _, binary_image = cv2.threshold(working_image, 0, 255, cv2.THRESH_BINARY_INV + cv2.THRESH_OTSU)
+        contours, _ = cv2.findContours(binary_image, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+
+        if not contours:
+            return image_array
+
+        largest_contour = max(contours, key=cv2.contourArea)
+        rotated_rectangle = cv2.minAreaRect(largest_contour)
+        angle = rotated_rectangle[2]
+
+        # minAreaRect returns angles in [-90, 0). Normalize to [-45, 45] range
+        if angle < -45.0:
+            angle = 90.0 + angle
+        elif angle > 45.0:
+            angle = angle - 90.0
+
+        if abs(angle) <= 0.5:
+            return image_array
+
+        logger.debug(f"Deskew angle: {angle:.2f} degrees")
+        height, width = image_array.shape[:2]
+        center = (width / 2.0, height / 2.0)
+        rotation_matrix = cv2.getRotationMatrix2D(center, angle, 1.0)
+        result: NDArray[np.uint8] = cv2.warpAffine(
+            image_array, rotation_matrix, (width, height), borderMode=cv2.BORDER_CONSTANT, borderValue=255
+        )
+        return result
+
+    def _binarize_image(self, image_array: NDArray[np.uint8]) -> NDArray[np.uint8]:
+        """Apply Otsu binarization to produce a black-and-white image.
+
+        Converts to grayscale first if the image is multi-channel.
+
+        Args:
+            image_array: Input image as a numpy array.
+
+        Returns:
+            Binary (black and white) image.
+        """
+        if len(image_array.shape) != 2:
+            image_array = cv2.cvtColor(image_array, cv2.COLOR_BGR2GRAY)
+
+        _, result = cv2.threshold(image_array, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)
+        binary_image: NDArray[np.uint8] = result
+        return binary_image
+
+    def _apply_morphology(self, image_array: NDArray[np.uint8]) -> NDArray[np.uint8]:
+        """Apply morphological opening followed by closing.
+
+        Uses a 1x1 kernel to remove small noise artifacts while preserving
+        character structure.
+
+        Args:
+            image_array: Input image as a numpy array.
+
+        Returns:
+            Morphologically cleaned image.
+        """
+        kernel: NDArray[np.uint8] = np.ones((1, 1), np.uint8)
+        opened: NDArray[np.uint8] = cv2.morphologyEx(image_array, cv2.MORPH_OPEN, kernel)
+        closed: NDArray[np.uint8] = cv2.morphologyEx(opened, cv2.MORPH_CLOSE, kernel)
+        return closed
+
+    def _add_border(self, image_array: NDArray[np.uint8]) -> NDArray[np.uint8]:
+        """Add a 10-pixel white border around the image.
+
+        Args:
+            image_array: Input image as a numpy array.
+
+        Returns:
+            Image with white border added on all sides.
+        """
+        result: NDArray[np.uint8] = cv2.copyMakeBorder(
+            image_array, 10, 10, 10, 10, cv2.BORDER_CONSTANT, value=255
+        )
+        return result
+
+    @staticmethod
+    def _pil_to_cv2(image: Image.Image) -> NDArray[np.uint8]:
+        """Convert PIL Image to OpenCV BGR numpy array.
+
+        Args:
+            image: Input PIL Image.
+
+        Returns:
+            OpenCV-compatible numpy array (BGR for color, grayscale for single-channel).
+        """
+        image_array: NDArray[np.uint8] = np.array(image)
+        if len(image_array.shape) == 3 and image_array.shape[2] == 3:
+            image_array = cv2.cvtColor(image_array, cv2.COLOR_RGB2BGR)
+        return image_array
+
+    @staticmethod
+    def _cv2_to_pil(image_array: NDArray[np.uint8]) -> Image.Image:
+        """Convert OpenCV numpy array to PIL Image.
+
+        Args:
+            image_array: OpenCV image array (BGR for color, grayscale for single-channel).
+
+        Returns:
+            PIL Image in RGB or grayscale mode.
+        """
+        if len(image_array.shape) == 3 and image_array.shape[2] == 3:
+            image_array = cv2.cvtColor(image_array, cv2.COLOR_BGR2RGB)
+        return Image.fromarray(image_array)

--- a/data_collector/processing/training.py
+++ b/data_collector/processing/training.py
@@ -1,0 +1,788 @@
+"""Training utilities for OCR model fine-tuning.
+
+Provides dataset management (loading, splitting, exporting), character dictionary
+building, PaddleOCR training config generation, and OCR accuracy evaluation with
+CER, WER, and exact-match metrics.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+from PIL import Image
+
+from data_collector.processing.models import TrainingError
+from data_collector.processing.ocr import OCREngine
+from data_collector.processing.preprocessing import ImagePreprocessor
+
+logger = logging.getLogger(__name__)
+
+_IMAGE_EXTENSIONS: frozenset[str] = frozenset({".png", ".jpg", ".jpeg", ".tif", ".tiff", ".bmp"})
+
+
+@dataclass(frozen=True)
+class TrainingSample:
+    """A single training sample pairing an image with its ground-truth text.
+
+    Attributes:
+        image_path: Absolute or relative path to the image file.
+        ground_truth: Expected OCR output text for the image.
+    """
+
+    image_path: Path
+    ground_truth: str
+
+
+@dataclass(frozen=True)
+class TrainingDatasetSplit:
+    """Result of splitting a training dataset into training and evaluation subsets.
+
+    Attributes:
+        training_samples: Immutable tuple of samples assigned to the training set.
+        evaluation_samples: Immutable tuple of samples assigned to the evaluation set.
+        training_count: Number of training samples.
+        evaluation_count: Number of evaluation samples.
+    """
+
+    training_samples: tuple[TrainingSample, ...]
+    evaluation_samples: tuple[TrainingSample, ...]
+    training_count: int
+    evaluation_count: int
+
+
+@dataclass(frozen=True)
+class AccuracyResult:
+    """Aggregated OCR accuracy metrics over a set of test samples.
+
+    Attributes:
+        character_error_rate: Character Error Rate (total edit distance / total reference length).
+        word_error_rate: Word Error Rate (total word-level edit distance / total word count).
+        total_samples: Number of samples evaluated.
+        correct_samples: Number of samples with exact string match.
+        exact_match_rate: Fraction of samples with exact match (0.0-1.0).
+        skipped_samples: Number of samples skipped due to errors (corrupt images, I/O failures).
+    """
+
+    character_error_rate: float
+    word_error_rate: float
+    total_samples: int
+    correct_samples: int
+    exact_match_rate: float
+    skipped_samples: int
+
+
+class TrainingDataset:
+    """Manages a collection of OCR training samples with load, split, and export capabilities.
+
+    Supports loading from PaddleOCR annotation format (tab-delimited) and Tesseract
+    paired-file format (image + .gt.txt). Provides deterministic splitting and export
+    to both PaddleOCR and Tesseract training directory structures.
+
+    Args:
+        samples: Initial list of TrainingSample instances.
+    """
+
+    def __init__(self, samples: list[TrainingSample]) -> None:
+        self._samples: list[TrainingSample] = list(samples)
+
+    @property
+    def samples(self) -> list[TrainingSample]:
+        """Return a copy of the internal sample list.
+
+        Returns:
+            New list containing all TrainingSample instances.
+        """
+        return list(self._samples)
+
+    @property
+    def sample_count(self) -> int:
+        """Return the number of samples in the dataset.
+
+        Returns:
+            Total number of training samples.
+        """
+        return len(self._samples)
+
+    @classmethod
+    def from_directory(cls, image_directory: Path, annotation_file: Path) -> TrainingDataset:
+        """Load a dataset from a PaddleOCR-format annotation file.
+
+        Each line in the annotation file has the format: ``image_path\\tground_truth``.
+        Image paths are resolved relative to ``image_directory``. Empty lines are skipped.
+        Samples whose resolved image path falls outside ``image_directory`` are skipped
+        with a warning (path traversal protection).
+
+        Args:
+            image_directory: Base directory containing the training images.
+            annotation_file: Path to the tab-delimited annotation file.
+
+        Returns:
+            TrainingDataset populated with samples from the annotation file.
+        """
+        loaded_samples: list[TrainingSample] = []
+        annotation_text = annotation_file.read_text(encoding="utf-8")
+        resolved_image_directory = image_directory.resolve()
+
+        for line_number, line in enumerate(annotation_text.splitlines(), start=1):
+            stripped_line = line.strip()
+            if not stripped_line:
+                continue
+
+            parts = stripped_line.split("\t", maxsplit=1)
+            if len(parts) != 2:
+                logger.warning(f"Skipping malformed line {line_number} in {annotation_file}: missing tab separator")
+                continue
+
+            relative_path, ground_truth = parts
+            image_path = image_directory / relative_path
+
+            if not image_path.resolve().is_relative_to(resolved_image_directory):
+                logger.warning(
+                    f"Skipping line {line_number} in {annotation_file}: "
+                    f"path traversal detected ({relative_path})"
+                )
+                continue
+
+            loaded_samples.append(TrainingSample(image_path=image_path, ground_truth=ground_truth))
+
+        logger.info(f"Loaded {len(loaded_samples)} samples from {annotation_file}")
+        return cls(loaded_samples)
+
+    @classmethod
+    def from_paired_files(cls, image_directory: Path) -> TrainingDataset:
+        """Load a dataset from Tesseract-style paired files.
+
+        Scans ``image_directory`` for image files (.png, .jpg, .jpeg, .tif, .tiff, .bmp)
+        and pairs each with a corresponding ``.gt.txt`` file containing the ground-truth text.
+        Images without a matching ``.gt.txt`` file are skipped with a warning.
+
+        Args:
+            image_directory: Directory containing image files and their ``.gt.txt`` counterparts.
+
+        Returns:
+            TrainingDataset populated with paired samples.
+        """
+        loaded_samples: list[TrainingSample] = []
+
+        image_files = sorted(
+            file_path
+            for file_path in image_directory.iterdir()
+            if file_path.is_file() and file_path.suffix.lower() in _IMAGE_EXTENSIONS
+        )
+
+        for image_file in image_files:
+            ground_truth_file = image_file.with_suffix(".gt.txt")
+            if not ground_truth_file.exists():
+                logger.warning(f"No .gt.txt file found for {image_file}, skipping")
+                continue
+
+            ground_truth = ground_truth_file.read_text(encoding="utf-8").strip()
+            loaded_samples.append(TrainingSample(image_path=image_file, ground_truth=ground_truth))
+
+        logger.info(f"Loaded {len(loaded_samples)} paired samples from {image_directory}")
+        return cls(loaded_samples)
+
+    def split(self, train_ratio: float = 0.9, seed: int = 42) -> TrainingDatasetSplit:
+        """Split the dataset into training and evaluation subsets.
+
+        Uses a seeded random shuffle for deterministic, reproducible splits.
+
+        Args:
+            train_ratio: Fraction of samples to assign to the training set (0.0-1.0).
+            seed: Random seed for reproducibility.
+
+        Returns:
+            TrainingDatasetSplit with training and evaluation samples.
+
+        Raises:
+            ValueError: If train_ratio is not between 0.0 and 1.0 inclusive.
+        """
+        if not 0.0 <= train_ratio <= 1.0:
+            raise ValueError(f"train_ratio must be between 0.0 and 1.0 inclusive, got {train_ratio}")
+
+        shuffled_samples = list(self._samples)
+        random.Random(seed).shuffle(shuffled_samples)
+
+        split_index = int(len(shuffled_samples) * train_ratio)
+        training_samples = tuple(shuffled_samples[:split_index])
+        evaluation_samples = tuple(shuffled_samples[split_index:])
+
+        result = TrainingDatasetSplit(
+            training_samples=training_samples,
+            evaluation_samples=evaluation_samples,
+            training_count=len(training_samples),
+            evaluation_count=len(evaluation_samples),
+        )
+
+        logger.info(f"Split dataset: {result.training_count} training, {result.evaluation_count} evaluation")
+        return result
+
+    def export_paddleocr(
+        self,
+        output_directory: Path,
+        *,
+        split: TrainingDatasetSplit | None = None,
+    ) -> Path:
+        """Export the dataset to PaddleOCR recognition training format.
+
+        Creates the following directory structure::
+
+            output_directory/
+                train/
+                    images/       -- training images
+                    rec_gt_train.txt  -- annotation file (relative_path\\ttext)
+                eval/
+                    images/       -- evaluation images
+                    rec_gt_eval.txt   -- annotation file (relative_path\\ttext)
+                dict.txt          -- character dictionary
+
+        Images are copied into the respective ``images/`` subdirectories. Annotation
+        files use paths relative to the ``train/`` or ``eval/`` directory.
+
+        Args:
+            output_directory: Root directory for the exported dataset.
+            split: Pre-computed dataset split. When None, calls ``self.split()`` with defaults.
+
+        Returns:
+            The output_directory path.
+
+        Raises:
+            TrainingError: If an image cannot be copied during export.
+        """
+        dataset_split = split if split is not None else self.split()
+
+        training_images_directory = output_directory / "train" / "images"
+        evaluation_images_directory = output_directory / "eval" / "images"
+        training_images_directory.mkdir(parents=True, exist_ok=True)
+        evaluation_images_directory.mkdir(parents=True, exist_ok=True)
+
+        training_annotation_path = output_directory / "train" / "rec_gt_train.txt"
+        evaluation_annotation_path = output_directory / "eval" / "rec_gt_eval.txt"
+
+        try:
+            _write_paddleocr_annotations(
+                dataset_split.training_samples, training_images_directory, training_annotation_path
+            )
+            _write_paddleocr_annotations(
+                dataset_split.evaluation_samples, evaluation_images_directory, evaluation_annotation_path
+            )
+        except TrainingError:
+            raise
+        except Exception as error:
+            raise TrainingError(f"PaddleOCR export failed: {error}") from error
+
+        character_dictionary = build_character_dictionary(self)
+        dictionary_path = output_directory / "dict.txt"
+        dictionary_path.write_text("\n".join(character_dictionary) + "\n", encoding="utf-8")
+
+        logger.info(
+            f"Exported PaddleOCR dataset to {output_directory}: "
+            f"{dataset_split.training_count} training, {dataset_split.evaluation_count} evaluation, "
+            f"{len(character_dictionary)} characters in dictionary"
+        )
+        return output_directory
+
+    def export_tesseract(self, output_directory: Path, model_name: str) -> Path:
+        """Export the dataset to Tesseract tesstrain format.
+
+        Creates the following directory structure::
+
+            output_directory/
+                data/
+                    {model_name}-ground-truth/
+                        sample_000000.tif   -- image (converted to TIFF)
+                        sample_000000.gt.txt -- ground-truth text
+
+        Images are converted to TIFF format if they are not already. Each sample
+        is named with a zero-padded index.
+
+        Args:
+            output_directory: Root directory for the exported dataset.
+            model_name: Tesseract model name used as the ground-truth directory prefix.
+
+        Returns:
+            The output_directory path.
+
+        Raises:
+            TrainingError: If an image cannot be opened or converted during export.
+        """
+        ground_truth_directory = output_directory / "data" / f"{model_name}-ground-truth"
+        ground_truth_directory.mkdir(parents=True, exist_ok=True)
+
+        for sample_index, sample in enumerate(self._samples):
+            base_name = f"sample_{sample_index:06d}"
+            target_image_path = ground_truth_directory / f"{base_name}.tif"
+            target_text_path = ground_truth_directory / f"{base_name}.gt.txt"
+
+            try:
+                if sample.image_path.suffix.lower() in {".tif", ".tiff"}:
+                    shutil.copy2(sample.image_path, target_image_path)
+                else:
+                    with Image.open(sample.image_path) as source_image:
+                        source_image.save(target_image_path, format="TIFF")
+
+                target_text_path.write_text(sample.ground_truth, encoding="utf-8")
+            except Exception as error:
+                raise TrainingError(
+                    f"Tesseract export failed at sample {sample_index} ({sample.image_path}): {error}",
+                    source_path=str(sample.image_path),
+                ) from error
+
+        logger.info(f"Exported Tesseract dataset to {ground_truth_directory}: {self.sample_count} samples")
+        return output_directory
+
+
+def _write_paddleocr_annotations(
+    samples: tuple[TrainingSample, ...],
+    images_directory: Path,
+    annotation_path: Path,
+) -> None:
+    """Copy images and write a PaddleOCR annotation file.
+
+    Each image is copied to ``images_directory`` with a unique index-prefixed filename
+    to prevent collisions from duplicate filenames. An annotation line is written
+    with the relative path (from the annotation file's parent) and ground-truth text.
+
+    Args:
+        samples: Tuple of training samples to export.
+        images_directory: Directory where images are copied.
+        annotation_path: Path to the annotation file to write.
+
+    Raises:
+        TrainingError: If an image cannot be copied.
+    """
+    annotation_lines: list[str] = []
+
+    for index, sample in enumerate(samples):
+        unique_filename = f"{index:06d}_{sample.image_path.name}"
+        destination = images_directory / unique_filename
+
+        try:
+            shutil.copy2(sample.image_path, destination)
+        except Exception as error:
+            raise TrainingError(
+                f"PaddleOCR annotation export failed at sample {index} ({sample.image_path}): {error}",
+                source_path=str(sample.image_path),
+            ) from error
+
+        relative_path = destination.relative_to(annotation_path.parent)
+        annotation_lines.append(f"{relative_path}\t{sample.ground_truth}")
+
+    annotation_path.write_text("\n".join(annotation_lines) + "\n", encoding="utf-8")
+
+
+def build_character_dictionary(
+    samples: list[TrainingSample] | TrainingDataset,
+    *,
+    include_special: bool = True,
+) -> list[str]:
+    """Build a sorted character dictionary from training samples.
+
+    Extracts all unique characters from ground-truth strings and sorts them by
+    Unicode codepoint. When ``include_special`` is True, ensures that space and
+    common punctuation characters are present even if not found in the samples.
+
+    Args:
+        samples: List of TrainingSample instances or a TrainingDataset.
+        include_special: Whether to include space and common punctuation characters.
+
+    Returns:
+        Sorted list of unique characters.
+    """
+    sample_list = samples.samples if isinstance(samples, TrainingDataset) else samples
+
+    characters: set[str] = set()
+    for sample in sample_list:
+        characters.update(sample.ground_truth)
+
+    if include_special:
+        special_characters = {" ", ".", ",", "!", "?", ";", ":", "'", '"', "-", "(", ")", "/", "&", "@", "#"}
+        characters.update(special_characters)
+
+    sorted_characters = sorted(characters, key=ord)
+    logger.info(f"Built character dictionary with {len(sorted_characters)} characters")
+    return sorted_characters
+
+
+def generate_paddleocr_config(
+    model_name: str,
+    dictionary_path: Path,
+    training_data_path: Path,
+    evaluation_data_path: Path,
+    *,
+    base_model: str = "PP-OCRv5",
+    language: str = "en",
+    epochs: int = 100,
+    learning_rate: float = 0.0001,
+    batch_size: int = 64,
+    output_directory: Path | None = None,
+) -> Path:
+    """Generate a PaddleOCR YAML training configuration file.
+
+    Writes a YAML config suitable for PaddleOCR's ``tools/train.py``. The config
+    includes Global settings (model name, pretrained model, dictionary, epochs),
+    Train/Eval data loader sections, and Optimizer settings.
+
+    No PyYAML dependency is required; the config is written as a formatted string.
+
+    Args:
+        model_name: Name for the trained model (used in output paths and config filename).
+        dictionary_path: Path to the character dictionary file (dict.txt).
+        training_data_path: Path to the training annotation file (e.g., rec_gt_train.txt).
+        evaluation_data_path: Path to the evaluation annotation file (e.g., rec_gt_eval.txt).
+        base_model: PaddleOCR base model identifier for pretrained weights.
+        language: Language code for the model.
+        epochs: Number of training epochs (must be >= 1).
+        learning_rate: Initial learning rate for the optimizer (must be > 0).
+        batch_size: Training batch size (must be >= 1).
+        output_directory: Directory to write the config file. Defaults to training_data_path's parent.
+
+    Returns:
+        Path to the generated YAML configuration file.
+
+    Raises:
+        TrainingError: If validation fails or config file cannot be written.
+    """
+    if epochs < 1:
+        raise TrainingError(f"epochs must be >= 1, got {epochs}")
+    if learning_rate <= 0:
+        raise TrainingError(f"learning_rate must be > 0, got {learning_rate}")
+    if batch_size < 1:
+        raise TrainingError(f"batch_size must be >= 1, got {batch_size}")
+
+    if output_directory is None:
+        output_directory = training_data_path.parent
+
+    output_directory.mkdir(parents=True, exist_ok=True)
+
+    config_path = output_directory / f"{model_name}_config.yml"
+
+    training_data_directory = training_data_path.parent
+    evaluation_data_directory = evaluation_data_path.parent
+
+    try:
+        config_content = (
+            f"Global:\n"
+            f"  use_gpu: true\n"
+            f"  epoch_num: {epochs}\n"
+            f"  log_smooth_window: 20\n"
+            f"  print_batch_step: 10\n"
+            f"  save_model_dir: ./output/{model_name}\n"
+            f"  save_epoch_step: 10\n"
+            f"  eval_batch_step:\n"
+            f"    - 0\n"
+            f"    - 2000\n"
+            f"  cal_metric_during_train: true\n"
+            f"  pretrained_model: {base_model}\n"
+            f"  character_dict_path: {dictionary_path}\n"
+            f"  use_space_char: true\n"
+            f"  max_text_length: 25\n"
+            f"  infer_img: null\n"
+            f"  character_type: {language}\n"
+            f"  model_name: {model_name}\n"
+            f"\n"
+            f"Optimizer:\n"
+            f"  name: Adam\n"
+            f"  beta1: 0.9\n"
+            f"  beta2: 0.999\n"
+            f"  lr:\n"
+            f"    name: Cosine\n"
+            f"    learning_rate: {learning_rate}\n"
+            f"    warmup_epoch: 5\n"
+            f"  regularizer:\n"
+            f"    name: L2\n"
+            f"    factor: 0.00001\n"
+            f"\n"
+            f"Architecture:\n"
+            f"  model_type: rec\n"
+            f"  algorithm: SVTR_LCNet\n"
+            f"  Transform: null\n"
+            f"  Backbone:\n"
+            f"    name: MobileNetV1Enhance\n"
+            f"    scale: 0.5\n"
+            f"    last_conv_stride:\n"
+            f"      - 1\n"
+            f"      - 2\n"
+            f"    last_pool_type: avg\n"
+            f"  Head:\n"
+            f"    name: MultiHead\n"
+            f"    head_list:\n"
+            f"      - CTCHead:\n"
+            f"          Neck:\n"
+            f"            name: svtr\n"
+            f"            dims: 64\n"
+            f"            depth: 2\n"
+            f"            hidden_dims: 120\n"
+            f"            use_guide: true\n"
+            f"          Head:\n"
+            f"            fc_decay: 0.00001\n"
+            f"      - SARHead:\n"
+            f"          enc_dim: 512\n"
+            f"          max_text_length: 25\n"
+            f"\n"
+            f"Loss:\n"
+            f"  name: MultiLoss\n"
+            f"  loss_config_list:\n"
+            f"    - CTCLoss: null\n"
+            f"    - SARLoss: null\n"
+            f"\n"
+            f"PostProcess:\n"
+            f"  name: CTCLabelDecode\n"
+            f"\n"
+            f"Metric:\n"
+            f"  name: RecMetric\n"
+            f"  main_indicator: acc\n"
+            f"\n"
+            f"Train:\n"
+            f"  dataset:\n"
+            f"    name: SimpleDataSet\n"
+            f"    data_dir: {training_data_directory}\n"
+            f"    label_file_list:\n"
+            f"      - {training_data_path}\n"
+            f"    transforms:\n"
+            f"      - DecodeImage:\n"
+            f"          img_mode: BGR\n"
+            f"          channel_first: false\n"
+            f"      - RecAug: null\n"
+            f"      - CTCLabelEncode: null\n"
+            f"      - RecResizeImg:\n"
+            f"          image_shape:\n"
+            f"            - 3\n"
+            f"            - 48\n"
+            f"            - 320\n"
+            f"      - KeepKeys:\n"
+            f"          keep_keys:\n"
+            f"            - image\n"
+            f"            - label\n"
+            f"            - length\n"
+            f"  loader:\n"
+            f"    shuffle: true\n"
+            f"    batch_size_per_card: {batch_size}\n"
+            f"    drop_last: true\n"
+            f"    num_workers: 4\n"
+            f"\n"
+            f"Eval:\n"
+            f"  dataset:\n"
+            f"    name: SimpleDataSet\n"
+            f"    data_dir: {evaluation_data_directory}\n"
+            f"    label_file_list:\n"
+            f"      - {evaluation_data_path}\n"
+            f"    transforms:\n"
+            f"      - DecodeImage:\n"
+            f"          img_mode: BGR\n"
+            f"          channel_first: false\n"
+            f"      - CTCLabelEncode: null\n"
+            f"      - RecResizeImg:\n"
+            f"          image_shape:\n"
+            f"            - 3\n"
+            f"            - 48\n"
+            f"            - 320\n"
+            f"      - KeepKeys:\n"
+            f"          keep_keys:\n"
+            f"            - image\n"
+            f"            - label\n"
+            f"            - length\n"
+            f"  loader:\n"
+            f"    shuffle: false\n"
+            f"    batch_size_per_card: {batch_size}\n"
+            f"    drop_last: false\n"
+            f"    num_workers: 4\n"
+        )
+
+        config_path.write_text(config_content, encoding="utf-8")
+    except TrainingError:
+        raise
+    except Exception as error:
+        raise TrainingError(f"Failed to generate PaddleOCR config: {error}") from error
+
+    logger.info(f"Generated PaddleOCR config at {config_path}")
+    return config_path
+
+
+def evaluate_ocr_accuracy(
+    engine: OCREngine,
+    test_samples: list[TrainingSample],
+    *,
+    additional_preprocessor: ImagePreprocessor | None = None,
+) -> AccuracyResult:
+    """Evaluate OCR engine accuracy against ground-truth samples.
+
+    For each test sample, opens the image, optionally applies additional preprocessing,
+    runs OCR via the provided engine, and compares the predicted text against the ground
+    truth. Corrupt or unreadable samples are skipped with a warning.
+
+    When ``additional_preprocessor`` is provided, it runs on the image before the engine's
+    own preprocessor (if any). This means both preprocessors will execute in sequence.
+
+    Computes three metrics:
+    - **CER** (Character Error Rate): total character-level edit distance divided by
+      total ground-truth character count.
+    - **WER** (Word Error Rate): total word-level edit distance divided by total
+      ground-truth word count.
+    - **Exact Match Rate**: fraction of samples where predicted text exactly matches
+      ground truth (after stripping whitespace).
+
+    Args:
+        engine: OCR engine instance to evaluate.
+        test_samples: List of TrainingSample instances with image paths and ground truth.
+        additional_preprocessor: Optional additional preprocessing applied before the engine's
+            own preprocessor. Both will run in sequence if the engine also has a preprocessor.
+
+    Returns:
+        AccuracyResult with CER, WER, total/correct sample counts, exact match rate,
+        and number of skipped samples.
+
+    Raises:
+        TrainingError: If evaluation fails for a reason other than individual sample errors.
+    """
+    total_character_distance = 0
+    total_character_count = 0
+    total_word_distance = 0
+    total_word_count = 0
+    correct_samples = 0
+    skipped_samples = 0
+
+    for sample_index, sample in enumerate(test_samples):
+        try:
+            with Image.open(sample.image_path) as image:
+                if additional_preprocessor is not None:
+                    image = additional_preprocessor.run(image)
+
+                ocr_result = engine.extract_text(image)
+
+            predicted_text = ocr_result.text.strip()
+            reference_text = sample.ground_truth.strip()
+
+            character_distance = _edit_distance(predicted_text, reference_text)
+            total_character_distance += character_distance
+            total_character_count += len(reference_text) if reference_text else 1
+
+            predicted_words = predicted_text.split()
+            reference_words = reference_text.split()
+            word_distance = _edit_distance_words(predicted_words, reference_words)
+            total_word_distance += word_distance
+            total_word_count += len(reference_words) if reference_words else 1
+
+            if predicted_text == reference_text:
+                correct_samples += 1
+        except Exception as error:
+            logger.warning(
+                f"Skipping sample {sample_index} ({sample.image_path}): "
+                f"{type(error).__name__}: {error}"
+            )
+            skipped_samples += 1
+            continue
+
+        if (sample_index + 1) % 100 == 0:
+            logger.info(f"Evaluated {sample_index + 1}/{len(test_samples)} samples")
+
+    evaluated_samples = len(test_samples) - skipped_samples
+    character_error_rate = total_character_distance / total_character_count if total_character_count > 0 else 0.0
+    word_error_rate = total_word_distance / total_word_count if total_word_count > 0 else 0.0
+    exact_match_rate = correct_samples / evaluated_samples if evaluated_samples > 0 else 0.0
+
+    result = AccuracyResult(
+        character_error_rate=character_error_rate,
+        word_error_rate=word_error_rate,
+        total_samples=evaluated_samples,
+        correct_samples=correct_samples,
+        exact_match_rate=exact_match_rate,
+        skipped_samples=skipped_samples,
+    )
+
+    logger.info(
+        f"OCR evaluation complete: CER={result.character_error_rate:.4f}, "
+        f"WER={result.word_error_rate:.4f}, exact_match={result.exact_match_rate:.4f} "
+        f"({result.correct_samples}/{result.total_samples})"
+        + (f", skipped={result.skipped_samples}" if result.skipped_samples > 0 else "")
+    )
+    return result
+
+
+def _edit_distance(source: str, target: str) -> int:
+    """Compute Levenshtein edit distance between two strings.
+
+    Uses the standard dynamic programming algorithm with O(min(m, n)) space.
+
+    Args:
+        source: Source string.
+        target: Target string.
+
+    Returns:
+        Minimum number of single-character insertions, deletions, and substitutions
+        required to transform source into target.
+    """
+    source_length = len(source)
+    target_length = len(target)
+
+    if source_length == 0:
+        return target_length
+    if target_length == 0:
+        return source_length
+
+    if source_length > target_length:
+        source, target = target, source
+        source_length, target_length = target_length, source_length
+
+    previous_row: list[int] = list(range(source_length + 1))
+    current_row: list[int] = [0] * (source_length + 1)
+
+    for target_index in range(1, target_length + 1):
+        current_row[0] = target_index
+        for source_index in range(1, source_length + 1):
+            deletion_cost = previous_row[source_index] + 1
+            insertion_cost = current_row[source_index - 1] + 1
+            substitution_cost = previous_row[source_index - 1]
+            if source[source_index - 1] != target[target_index - 1]:
+                substitution_cost += 1
+            current_row[source_index] = min(deletion_cost, insertion_cost, substitution_cost)
+        previous_row, current_row = current_row, previous_row
+
+    return previous_row[source_length]
+
+
+def _edit_distance_words(source_words: list[str], target_words: list[str]) -> int:
+    """Compute Levenshtein edit distance between two word sequences.
+
+    Same algorithm as character-level edit distance but operates on lists of words
+    instead of individual characters.
+
+    Args:
+        source_words: Source word sequence.
+        target_words: Target word sequence.
+
+    Returns:
+        Minimum number of word-level insertions, deletions, and substitutions
+        required to transform source_words into target_words.
+    """
+    source_length = len(source_words)
+    target_length = len(target_words)
+
+    if source_length == 0:
+        return target_length
+    if target_length == 0:
+        return source_length
+
+    if source_length > target_length:
+        source_words, target_words = target_words, source_words
+        source_length, target_length = target_length, source_length
+
+    previous_row: list[int] = list(range(source_length + 1))
+    current_row: list[int] = [0] * (source_length + 1)
+
+    for target_index in range(1, target_length + 1):
+        current_row[0] = target_index
+        for source_index in range(1, source_length + 1):
+            deletion_cost = previous_row[source_index] + 1
+            insertion_cost = current_row[source_index - 1] + 1
+            substitution_cost = previous_row[source_index - 1]
+            if source_words[source_index - 1] != target_words[target_index - 1]:
+                substitution_cost += 1
+            current_row[source_index] = min(deletion_cost, insertion_cost, substitution_cost)
+        previous_row, current_row = current_row, previous_row
+
+    return previous_row[source_length]

--- a/data_collector/settings/processing.py
+++ b/data_collector/settings/processing.py
@@ -1,0 +1,111 @@
+"""Pydantic settings for PDF/OCR processing configuration."""
+
+from __future__ import annotations
+
+from pydantic import field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class ProcessingSettings(BaseSettings):
+    """PDF/OCR processing settings loaded from environment variables.
+
+    Environment variables follow the ``DC_PROCESSING_`` prefix pattern:
+
+        DC_PROCESSING_TEXT_THRESHOLD         -- Fraction of pages (0.0-1.0) that must
+                                                have extractable text for a PDF to be
+                                                classified as text-based. Default: 0.9.
+        DC_PROCESSING_MIN_TEXT_LENGTH        -- Minimum character count for a page to be
+                                                considered as having meaningful text.
+                                                Default: 50.
+        DC_PROCESSING_TESSERACT_LANGUAGE     -- Tesseract language string (e.g., ``"eng"``,
+                                                ``"eng+hrv"``). Default: ``"eng"``.
+        DC_PROCESSING_TESSERACT_CMD          -- Path to the Tesseract executable. When
+                                                empty, pytesseract uses its default PATH
+                                                lookup. Default: ``""`` (empty).
+        DC_PROCESSING_MIN_DPI                -- Minimum DPI threshold for OCR preprocessing.
+                                                Images below this DPI are upscaled.
+                                                Default: 300.
+        DC_PROCESSING_PREPROCESSING_ENABLED  -- Enable the full preprocessing pipeline
+                                                (grayscale, upscale, denoise, contrast,
+                                                deskew, binarize, morphology, border)
+                                                before OCR. Default: True.
+        DC_PROCESSING_CLAHE_CLIP_LIMIT       -- CLAHE contrast clip limit. Controls how
+                                                much contrast enhancement is applied.
+                                                Default: 2.0.
+        DC_PROCESSING_CLAHE_TILE_SIZE        -- CLAHE tile grid size. Determines the size
+                                                of local regions for adaptive histogram
+                                                equalization. Default: 8.
+
+    Examples:
+        From environment variables::
+
+            settings = ProcessingSettings()
+            doc_type = classify_pdf(path, threshold=settings.text_threshold)
+
+        Direct construction (testing)::
+
+            settings = ProcessingSettings(text_threshold=0.8, tesseract_language="eng+hrv")
+    """
+
+    model_config = SettingsConfigDict(env_prefix="DC_PROCESSING_")
+
+    # -- PDF classification --
+    text_threshold: float = 0.9
+    min_text_length: int = 50
+
+    # -- Tesseract configuration --
+    tesseract_language: str = "eng"
+    tesseract_cmd: str = ""
+
+    # -- Preprocessing --
+    min_dpi: int = 300
+    preprocessing_enabled: bool = True
+
+    # -- CLAHE contrast enhancement --
+    clahe_clip_limit: float = 2.0
+    clahe_tile_size: int = 8
+
+    @field_validator("text_threshold")
+    @classmethod
+    def validate_text_threshold(cls, value: float) -> float:
+        """Validate that text_threshold is between 0.0 and 1.0 inclusive."""
+        if not 0.0 <= value <= 1.0:
+            message = f"text_threshold must be between 0.0 and 1.0, got {value}"
+            raise ValueError(message)
+        return value
+
+    @field_validator("min_text_length")
+    @classmethod
+    def validate_min_text_length(cls, value: int) -> int:
+        """Validate that min_text_length is positive."""
+        if value < 1:
+            message = f"min_text_length must be >= 1, got {value}"
+            raise ValueError(message)
+        return value
+
+    @field_validator("min_dpi")
+    @classmethod
+    def validate_min_dpi(cls, value: int) -> int:
+        """Validate that min_dpi is a reasonable DPI value."""
+        if value < 72:
+            message = f"min_dpi must be >= 72, got {value}"
+            raise ValueError(message)
+        return value
+
+    @field_validator("clahe_clip_limit")
+    @classmethod
+    def validate_clahe_clip_limit(cls, value: float) -> float:
+        """Validate that clahe_clip_limit is positive."""
+        if value <= 0:
+            message = f"clahe_clip_limit must be > 0, got {value}"
+            raise ValueError(message)
+        return value
+
+    @field_validator("clahe_tile_size")
+    @classmethod
+    def validate_clahe_tile_size(cls, value: int) -> int:
+        """Validate that clahe_tile_size is at least 2."""
+        if value < 2:
+            message = f"clahe_tile_size must be >= 2, got {value}"
+            raise ValueError(message)
+        return value

--- a/docs/14. pdf-ocr.md
+++ b/docs/14. pdf-ocr.md
@@ -2,13 +2,15 @@
 
 # PDF & OCR Processing
 
-**Implementation Status:** IN DEVELOPMENT | **Work Package:** WP-14 | **Milestone:** v0.5.0
+**Implementation Status:** IMPLEMENTED | **Work Package:** WP-14 | **Milestone:** v0.5.0
 
 ## Overview
 
-Extract structured data from PDF documents and scanned images. Built from the ground up based on enterprise experience. Uses **pdfplumber** as the primary PDF text extraction library and an OCR adapter pattern supporting multiple engines.
+Extract structured data from PDF documents and scanned images. Built from the ground up based on enterprise experience. Uses **pdfplumber** for PDF text/table extraction and an **OCR adapter pattern** with PaddleOCR (primary) and Tesseract (fallback).
 
-Developed and tested primarily on Windows, but fully deployable on Linux.
+PDF/OCR processing runs as **Dramatiq pipeline stages** (separate worker processes). This is a clear separation from `BaseScraper.collect()`, which handles HTML from HTTP requests.
+
+Developed and tested primarily on Windows, fully deployable on Linux.
 
 ## PDF Processing Flow
 
@@ -16,218 +18,362 @@ Developed and tested primarily on Windows, but fully deployable on Linux.
 Input PDF
     |
     v
-Classify Document (text-based vs image-based)
+classify_pdf() -- Whole-document classification
     |
     +--- 90%+ pages have extractable text ---> Text Path (pdfplumber)
     |
     +--- Otherwise ----------------------------> Image Path (OCR engine)
     |
     v
-Structured Output
+Structured Output (PDFText / OCRResult)
 ```
 
 ### Whole-Document Classification
 
-The framework classifies each PDF as **text-based** or **image-based** using a 90% threshold:
+The framework classifies each PDF as **text-based** or **image-based** using a configurable threshold (default 90%):
 
-- If **90% or more** of pages have extractable text -> **text mode** (use pdfplumber)
-- Otherwise -> **image/OCR mode** (use OCR engine)
+- If **90% or more** of pages have extractable text (>50 characters) -> `PdfDataType.TEXT`
+- Otherwise -> `PdfDataType.IMAGE`
 
 There is no per-page mixed mode. The entire document is processed through one path.
 
 ```python
-import pdfplumber
+from data_collector.processing import classify_pdf
+from data_collector.enums.processing import PdfDataType
 
-def classify_pdf(pdf_path: str, threshold: float = 0.9) -> str:
-    """Classify a PDF as 'text' or 'image' based on extractable text content."""
-    with pdfplumber.open(pdf_path) as pdf:
-        text_pages = 0
-        for page in pdf.pages:
-            text = page.extract_text()
-            if text and len(text.strip()) > 50:  # meaningful text content
-                text_pages += 1
-        ratio = text_pages / len(pdf.pages) if pdf.pages else 0
-        return "text" if ratio >= threshold else "image"
+classification = classify_pdf("document.pdf", threshold=0.9, min_text_length=50)
+
+if classification.document_type == PdfDataType.TEXT:
+    # Use pdfplumber for text extraction
+    ...
+else:
+    # Use OCR engine for image-based extraction
+    ...
+
+# Rich classification metadata
+print(f"Type: {classification.document_type}")
+print(f"Pages: {classification.total_pages}")
+print(f"Text pages: {classification.text_pages}")
+print(f"Text ratio: {classification.text_ratio:.2f}")
 ```
 
 ## Text Extraction (pdfplumber)
 
-**pdfplumber** is the primary library for all PDF text and table extraction.
+**pdfplumber** is the primary library for all PDF text and table extraction on native (text-based) PDFs.
 
 ```python
-import pdfplumber
+from data_collector.processing import extract_text_pdfplumber, extract_tables_pdfplumber
 
-with pdfplumber.open("document.pdf") as pdf:
-    for page in pdf.pages:
-        text = page.extract_text()
-        tables = page.extract_tables()
+# Extract all text
+result = extract_text_pdfplumber("document.pdf")
+print(result.full_text)          # Concatenated text from all pages
+for page in result.pages:
+    print(f"Page {page.page_number}: {page.text[:100]}...")
+
+# Extract specific pages (1-based indexing)
+result = extract_text_pdfplumber("document.pdf", page_numbers=[1, 3, 5])
+
+# Extract tables
+tables = extract_tables_pdfplumber("financial_report.pdf")
+print(f"Found {tables.total_tables} tables")
+for table in tables.tables:
+    print(f"Page {table.page_number}: {len(table.rows)} rows")
+    for row in table.rows:
+        print(row)  # Tuple of str | None values
+
+# Custom table extraction settings
+tables = extract_tables_pdfplumber(
+    "document.pdf",
+    table_settings={"vertical_strategy": "text", "horizontal_strategy": "text"},
+)
 ```
-
-### Table Extraction
-
-```python
-with pdfplumber.open("financial_report.pdf") as pdf:
-    page = pdf.pages[0]
-    table = page.extract_table()
-    # Returns list of lists: [['Header1', 'Header2'], ['val1', 'val2'], ...]
-```
-
-| Tool | Strengths | Limitations |
-|------|-----------|-------------|
-| **pdfplumber** | High accuracy, text + table extraction, detailed control | Native PDFs only |
-| **Camelot** | Good for lattice tables | Requires Ghostscript |
-| **Tabula** | Easy setup | Less flexible |
 
 ## OCR Engine
 
-### OCR Adapter Pattern
+### Architecture
 
-The framework uses an `OCREngine` adapter with pluggable implementations:
-
-```python
-from abc import ABC, abstractmethod
-
-class OCREngine(ABC):
-    """Abstract OCR engine interface."""
-
-    @abstractmethod
-    def extract_text(self, image) -> str:
-        """Extract text from a PIL Image."""
-        ...
-
-class TesseractEngine(OCREngine):
-    """Default OCR engine — Tesseract via pytesseract."""
-
-    def extract_text(self, image) -> str:
-        import pytesseract
-        return pytesseract.image_to_string(image, lang=self.lang)
-
-class PaddleOCREngine(OCREngine):
-    """Optional OCR engine — requires separate install of paddleocr."""
-
-    def extract_text(self, image) -> str:
-        result = self.ocr.ocr(image, cls=True)
-        return "\n".join(line[1][0] for line in result[0])
-```
-
-### Tesseract (Default)
+PaddleOCR is the **primary engine** (F1=0.938, superior accuracy). Tesseract is the **fallback** (lighter, no model downloads). Both are hard dependencies.
 
 ```python
-import pytesseract
-from PIL import Image
+from data_collector.processing import (
+    extract_text_ocr, PaddleOCREngine, TesseractEngine, ImagePreprocessor,
+)
 
-text = pytesseract.image_to_string(Image.open("scan.png"), lang="eng+hrv")
-```
+# Default: PaddleOCR (primary engine)
+result = extract_text_ocr("scanned_document.png")
+print(f"Text: {result.text}")
+print(f"Engine: {result.engine_name}")        # "paddleocr"
+print(f"Confidence: {result.confidence:.2f}")  # 0.0-1.0
 
-### PaddleOCR (Optional)
+# Explicit PaddleOCR with Croatian language
+engine = PaddleOCREngine(language="hr")
+result = extract_text_ocr("croatian_document.png", engine=engine)
 
-Requires separate installation (`pip install paddleocr`).
+# Tesseract fallback (local dev, testing)
+engine = TesseractEngine(language="eng+hrv")
+result = extract_text_ocr("scan.png", engine=engine)
 
-```python
-from paddleocr import PaddleOCR
-
-ocr = PaddleOCR(use_angle_cls=True, lang='en')
-result = ocr.ocr("document.png", cls=True)
-for line in result[0]:
-    text = line[1][0]
-    confidence = line[1][1]
+# With preprocessing
+preprocessor = ImagePreprocessor(min_dpi=300)
+engine = PaddleOCREngine(language="en", preprocessor=preprocessor)
+result = engine.extract_text(pil_image, dpi=150)
+print(f"Preprocessed: {result.preprocessed}")  # True
 ```
 
 ### Engine Comparison
 
-| Engine | Accuracy | Speed | Languages | Layout | Install |
-|--------|----------|-------|-----------|--------|---------|
-| Tesseract | Good | Fast (CPU) | 100+ | Basic | Default |
-| PaddleOCR | Very good | Medium | 80+ | Advanced | Optional |
+| Engine | Role | Accuracy | Speed | Languages | Install |
+|--------|------|----------|-------|-----------|---------|
+| **PaddleOCR** | Primary | F1=0.938 | ~4.6s/image | 100+ | Hard dependency |
+| **Tesseract** | Fallback | F1=0.797 | ~0.8s/image | 100+ | Hard dependency + binary |
 
-### Image Preprocessing Pipeline
+### Concurrency (Dramatiq Workers)
 
-For optimal OCR results, preprocess images before extraction:
+OCR runs exclusively in Dramatiq worker processes. Each worker creates its own engine instance:
+
+- **PaddleOCR**: ~2-5s init, ~300-500MB memory, reused across calls within the worker
+- **Tesseract**: Instant init, ~50-100MB, each call spawns a subprocess
+- No thread-safety concerns -- each worker is a separate OS process
+- Model files downloaded once on first use, cached locally
+
+### Prerequisites
+
+**Tesseract binary** (required for TesseractEngine):
+- Windows: [installer](https://github.com/UB-Mannheim/tesseract/wiki), adds to PATH
+- Linux: `apt install tesseract-ocr tesseract-ocr-hrv`
+- Set `DC_PROCESSING_TESSERACT_CMD` if not on PATH
+
+**PaddleOCR models** (~100MB, downloaded on first use):
+- For enterprise deployment, pre-download models to avoid first-use network calls
+- Models cached in `~/.paddleocr/` by default
+
+## Image Preprocessing Pipeline
+
+8-stage pipeline based on Tesseract best practices and OCR research. Each stage independently toggleable.
 
 ```
-Input Image
+Input Image (PIL)
     |
-    v
-Deskew (correct rotation)
+1. Grayscale -----> cv2.cvtColor(BGR2GRAY)
+2. Upscale -------> cv2.resize(INTER_CUBIC)           [if DPI < min_dpi]
+3. Denoise -------> cv2.fastNlMeansDenoising(h=10)
+4. Contrast ------> cv2.createCLAHE(clipLimit, tile)   [CLAHE: ~15% accuracy gain]
+5. Deskew --------> minAreaRect + warpAffine            [up to 20% accuracy gain]
+6. Binarize ------> cv2.threshold(THRESH_OTSU)
+7. Morphology ----> MORPH_OPEN + MORPH_CLOSE
+8. Border --------> cv2.copyMakeBorder(10px white)
     |
-    v
-Binarize (convert to B&W)
-    |
-    v
-Denoise (remove noise)
-    |
-    v
-Upscale (if DPI < 300)
-    |
-    v
-OCR Engine
+Output Image (PIL)
 ```
 
-Libraries: **OpenCV** for preprocessing, **Pillow** for format conversion.
+### Pipeline Order Rationale
+
+- **Grayscale first**: all subsequent operations expect single-channel input
+- **Upscale early**: prevents processing artifacts on low-resolution images
+- **Denoise before contrast**: prevents CLAHE from amplifying noise
+- **Contrast before binarize**: CLAHE improves Otsu threshold determination
+- **Deskew before binarize**: rotation on grayscale produces better interpolation
+- **Morphology after binarize**: operates on clean B&W image
+- **Border last**: ensures proper whitespace margins for Tesseract
+
+### Usage
+
+```python
+from data_collector.processing import ImagePreprocessor
+
+# Full pipeline (all 8 stages)
+preprocessor = ImagePreprocessor(min_dpi=300)
+processed = preprocessor.run(pil_image, dpi=150)
+
+# Selective stages
+preprocessor = ImagePreprocessor(
+    deskew=False,      # Skip deskew for well-aligned documents
+    morphology=False,  # Skip morphology for clean text
+)
+
+# Custom CLAHE parameters
+preprocessor = ImagePreprocessor(
+    clahe_clip_limit=3.0,  # Stronger contrast enhancement
+    clahe_tile_size=16,    # Larger local regions
+)
+```
+
+### Per-Engine Preprocessing Guidance
+
+| Engine | Built-in Preprocessing | ImagePreprocessor |
+|--------|----------------------|-------------------|
+| **PaddleOCR** | Orientation (0/90/180/270), geometric unwarping, normalization | Optional. Beneficial for noisy/low-quality scans. |
+| **Tesseract** | Minimal (basic internal binarization) | Always recommended. Accuracy depends on input quality. |
+
+## Configuration
+
+All settings via environment variables with `DC_PROCESSING_` prefix:
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `DC_PROCESSING_TEXT_THRESHOLD` | float | 0.9 | Text classification threshold (0.0-1.0) |
+| `DC_PROCESSING_MIN_TEXT_LENGTH` | int | 50 | Minimum chars for a page to count as text |
+| `DC_PROCESSING_TESSERACT_LANGUAGE` | str | "eng" | Tesseract language string |
+| `DC_PROCESSING_TESSERACT_CMD` | str | "" | Path to Tesseract binary |
+| `DC_PROCESSING_MIN_DPI` | int | 300 | Minimum DPI for upscale stage |
+| `DC_PROCESSING_PREPROCESSING_ENABLED` | bool | True | Enable/disable preprocessing pipeline |
+| `DC_PROCESSING_CLAHE_CLIP_LIMIT` | float | 2.0 | CLAHE contrast clip limit |
+| `DC_PROCESSING_CLAHE_TILE_SIZE` | int | 8 | CLAHE tile grid size |
+
+```python
+from data_collector.settings.processing import ProcessingSettings
+
+settings = ProcessingSettings()
+# Or override: ProcessingSettings(text_threshold=0.8, tesseract_language="eng+hrv")
+```
+
+## Training Utilities
+
+The framework provides dataset preparation, export, and evaluation utilities for fine-tuning OCR models on domain-specific data. Training execution runs externally via engine-specific CLI tools.
+
+### Workflow
+
+```
+1. Collect corrections -----> Operator corrects OCR output
+2. Build dataset ------------> TrainingDataset.from_directory()
+3. Export to engine format --> dataset.export_paddleocr() / .export_tesseract()
+4. Generate config ----------> generate_paddleocr_config()
+5. Run training (external) --> python tools/train.py -c config.yml
+6. Evaluate -----------------> evaluate_ocr_accuracy()
+```
+
+### Dataset Preparation
+
+```python
+from data_collector.processing import TrainingDataset, TrainingSample
+
+# Load from PaddleOCR format (tab-separated annotation file)
+dataset = TrainingDataset.from_directory(
+    image_directory=Path("corrections/images"),
+    annotation_file=Path("corrections/annotations.txt"),
+)
+# annotations.txt format: image_001.png\tDragan Matešić
+
+# Load from Tesseract paired files
+dataset = TrainingDataset.from_paired_files(
+    image_directory=Path("corrections/"),
+)
+# Expects: image_001.png + image_001.gt.txt pairs
+
+# Split for training
+split = dataset.split(train_ratio=0.9, seed=42)
+print(f"Training: {split.training_count}, Evaluation: {split.evaluation_count}")
+```
+
+### Export and Training
+
+```python
+from data_collector.processing import (
+    build_character_dictionary, generate_paddleocr_config,
+)
+
+# Export to PaddleOCR format
+output_path = dataset.export_paddleocr(Path("training_data/paddleocr"))
+# Creates: train/images/, eval/images/, rec_gt_train.txt, rec_gt_eval.txt, dict.txt
+
+# Export to Tesseract format
+output_path = dataset.export_tesseract(Path("training_data/tesseract"), model_name="hrv_custom")
+# Creates: data/hrv_custom-ground-truth/ with .tif + .gt.txt pairs
+
+# Generate PaddleOCR training config
+config_path = generate_paddleocr_config(
+    model_name="hr_custom_v1",
+    dictionary_path=Path("training_data/paddleocr/dict.txt"),
+    training_data_path=Path("training_data/paddleocr/train/rec_gt_train.txt"),
+    evaluation_data_path=Path("training_data/paddleocr/eval/rec_gt_eval.txt"),
+    base_model="PP-OCRv5",
+    language="hr",
+    epochs=100,
+    learning_rate=0.0001,
+)
+# Then run PaddleOCR training externally (see PaddleOCR documentation)
+```
+
+### Accuracy Evaluation
+
+```python
+from data_collector.processing import evaluate_ocr_accuracy, PaddleOCREngine
+
+engine = PaddleOCREngine(language="hr")
+result = evaluate_ocr_accuracy(engine, test_samples)
+
+print(f"CER: {result.character_error_rate:.4f}")   # 0.0 = perfect
+print(f"WER: {result.word_error_rate:.4f}")         # 0.0 = perfect
+print(f"Exact match: {result.exact_match_rate:.2%}")
+print(f"Correct: {result.correct_samples}/{result.total_samples}")
+```
+
+### OCR Training Signal Detection
+
+When operators correct OCR output, compare the correction against the original:
+
+- **CER > threshold** -> flag for OCR retraining (text recognition errors)
+- **CER <= threshold** -> minor corrections, log only
+- **Field corrections without text changes** -> NER/extraction training signal (WP-16)
 
 ## Integration with Framework
 
-PDF/OCR processing integrates at two levels: inline within a scraper's `collect()` method (for simple cases), or as a standalone Dramatiq worker stage in a multi-step pipeline (for high-volume document processing).
-
-### Inline in BaseScraper
-
-For scrapers that download and process PDFs as part of collection:
+PDF/OCR processing integrates as **Dramatiq worker stages** in multi-step pipelines. State is tracked in `PipelineTask` (WP-10).
 
 ```python
-class CourtFilings(BaseScraper):
-    def collect(self):
-        for case in self.work_list:
-            pdf_bytes = self.request.get(case.pdf_url).content
-            pdf_path = save_temp(pdf_bytes)
+from data_collector.processing import classify_pdf, extract_text_pdfplumber, extract_text_ocr
+from data_collector.processing import PaddleOCREngine, ImagePreprocessor
+from data_collector.enums.processing import PdfDataType
 
-            doc_type = classify_pdf(pdf_path)
-            if doc_type == "text":
-                text = extract_text_pdfplumber(pdf_path)
-            else:
-                text = extract_text_ocr(pdf_path, engine=TesseractEngine())
+# Dramatiq worker stage
+classification = classify_pdf(pdf_path)
 
-            records = self.parser.parse_filing(text, case.case_id)
-            self.store(records)
-            self.solved += 1
-```
-
-### As a Pipeline Stage (Dramatiq Worker)
-
-For high-volume document processing, PDF/OCR runs as a Dramatiq worker stage with state tracked in `PipelineTask`. See [17.1. dramatiq.md](17.1.%20dramatiq.md#generic-infrastructure-actor) for the `process_pdf` actor pattern.
-
-```python
-# Classify → extract text → forward to next stage
-doc_type = classify_pdf(pdf_path)
-
-if doc_type == "text":
+if classification.document_type == PdfDataType.TEXT:
     pdf_text = extract_text_pdfplumber(pdf_path)
+    text = pdf_text.full_text
 else:
-    pdf_text = extract_text_ocr(pdf_path, engine=TesseractEngine())
+    preprocessor = ImagePreprocessor(min_dpi=300)
+    engine = PaddleOCREngine(language="hr", preprocessor=preprocessor)
+    ocr_result = extract_text_ocr(pdf_path, engine=engine)
+    text = ocr_result.text
 
-records = parse_company_data(pdf_text)
+records = parse_company_data(text)
 bulk_hash(records)
 
 with database.create_session() as session:
     database.merge(records, session, filters=filters)
 ```
 
-## Recommended Libraries
+## Module Structure
 
-| Library | Purpose | Status |
-|---------|---------|--------|
-| `pdfplumber` | PDF text + table extraction (primary) | To be added |
-| `pytesseract` | Tesseract OCR wrapper (default engine) | To be added |
-| `Pillow` | Image manipulation | To be added |
-| `opencv-python` | Image preprocessing | To be added |
-| `paddleocr` | Advanced OCR (optional engine) | To be added |
+```
+data_collector/processing/
+    __init__.py          # Package exports
+    models.py            # PDFClassification, OCRResult, exceptions
+    preprocessing.py     # ImagePreprocessor (8-stage OpenCV pipeline)
+    pdf.py               # classify_pdf, extract_text_pdfplumber, extract_tables_pdfplumber
+    ocr.py               # OCREngine ABC, PaddleOCREngine, TesseractEngine, extract_text_ocr
+    training.py          # TrainingDataset, export, dictionary, config, evaluation
+
+data_collector/enums/processing.py     # PdfDataType StrEnum
+data_collector/settings/processing.py  # ProcessingSettings (DC_PROCESSING_ prefix)
+```
 
 ## Dependencies
 
-- **pdfplumber** — PDF text and table extraction (primary)
-- **pytesseract** — Tesseract OCR wrapper (default engine)
-- **Pillow** — Image manipulation and format conversion
-- **opencv-python** — Image preprocessing (deskew, binarize, denoise)
-- **paddleocr** — Advanced OCR engine (optional, separate install)
+| Library | Purpose | License | Status |
+|---------|---------|---------|--------|
+| `pdfplumber` | PDF text + table extraction | MIT | Installed |
+| `pytesseract` | Tesseract OCR wrapper (fallback) | Apache 2.0 | Installed |
+| `Pillow` | Image manipulation and format conversion | HPND | Installed |
+| `opencv-python-headless` | Image preprocessing (8-stage pipeline) | Apache 2.0 | Installed |
+| `paddleocr` | PaddleOCR engine (primary) | Apache 2.0 | Installed |
+| `paddlepaddle` | PaddlePaddle framework (PaddleOCR runtime) | Apache 2.0 | Installed |
+
+External system requirements:
+- **Tesseract binary** -- required only for TesseractEngine (fallback)
+
+Downstream consumers:
 - NER pipeline for entity extraction ([21. deep-learning-ner.md](21.%20deep-learning-ner.md))
 - OCR output feeds into Dramatiq pipeline workers ([17.1. dramatiq.md](17.1.%20dramatiq.md#worker-patterns))
 - Dramatiq + RabbitMQ for pipeline worker stages ([17. rabbitmq.md](17.%20rabbitmq.md))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ dev = [
     "zeep>=4.2.0",
     "lxml-stubs>=0.5.1"
 ]
+gpu = [
+    "paddlepaddle-gpu>=3.0.0"
+]
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,9 @@ croniter>=1.4.1
 dramatiq[rabbitmq]>=2.1.0
 watchdog>=6.0.0
 pywin32>=310; sys_platform == "win32"
+pdfplumber>=0.11.0
+pytesseract>=0.3.13
+Pillow>=11.0.0
+opencv-python-headless>=4.10.0
+paddleocr>=3.0.0
+paddlepaddle>=3.0.0

--- a/tests/unit/processing/test_models.py
+++ b/tests/unit/processing/test_models.py
@@ -1,0 +1,236 @@
+"""Tests for processing data models, enums, and exception types."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from data_collector.enums.processing import PdfDataType
+from data_collector.processing.models import (
+    OCRError,
+    OCRResult,
+    PageText,
+    PDFClassification,
+    PDFExtractionError,
+    PDFTable,
+    PDFTables,
+    PDFText,
+    PreprocessingError,
+    ProcessingError,
+)
+
+
+class TestPdfDataType:
+    """Tests for PdfDataType StrEnum values."""
+
+    def test_text_value(self) -> None:
+        assert PdfDataType.TEXT == "text"
+
+    def test_image_value(self) -> None:
+        assert PdfDataType.IMAGE == "image"
+
+    def test_member_count(self) -> None:
+        assert len(PdfDataType) == 2
+
+    def test_is_str(self) -> None:
+        assert isinstance(PdfDataType.TEXT, str)
+        assert isinstance(PdfDataType.IMAGE, str)
+
+
+class TestPDFClassification:
+    """Tests for PDFClassification frozen dataclass."""
+
+    def test_construction(self) -> None:
+        classification = PDFClassification(
+            document_type=PdfDataType.TEXT,
+            total_pages=10,
+            text_pages=9,
+            text_ratio=0.9,
+        )
+        assert classification.document_type == PdfDataType.TEXT
+        assert classification.total_pages == 10
+        assert classification.text_pages == 9
+        assert classification.text_ratio == 0.9
+
+    def test_frozen(self) -> None:
+        classification = PDFClassification(
+            document_type=PdfDataType.IMAGE,
+            total_pages=5,
+            text_pages=1,
+            text_ratio=0.2,
+        )
+        with pytest.raises(FrozenInstanceError):
+            classification.total_pages = 20  # type: ignore[misc]
+
+    def test_all_attributes_accessible(self) -> None:
+        classification = PDFClassification(
+            document_type=PdfDataType.TEXT,
+            total_pages=1,
+            text_pages=1,
+            text_ratio=1.0,
+        )
+        assert hasattr(classification, "document_type")
+        assert hasattr(classification, "total_pages")
+        assert hasattr(classification, "text_pages")
+        assert hasattr(classification, "text_ratio")
+
+
+class TestPageText:
+    """Tests for PageText frozen dataclass."""
+
+    def test_construction(self) -> None:
+        page = PageText(page_number=1, text="Hello world")
+        assert page.page_number == 1
+        assert page.text == "Hello world"
+
+    def test_frozen(self) -> None:
+        page = PageText(page_number=1, text="content")
+        with pytest.raises(FrozenInstanceError):
+            page.text = "modified"  # type: ignore[misc]
+
+
+class TestPDFText:
+    """Tests for PDFText frozen dataclass."""
+
+    def test_construction_with_pages(self) -> None:
+        page_one = PageText(page_number=1, text="First page")
+        page_two = PageText(page_number=2, text="Second page")
+        pdf_text = PDFText(
+            pages=(page_one, page_two),
+            full_text="First page\nSecond page",
+        )
+        assert len(pdf_text.pages) == 2
+        assert pdf_text.pages[0].text == "First page"
+        assert pdf_text.pages[1].text == "Second page"
+
+    def test_full_text_accessible(self) -> None:
+        page = PageText(page_number=1, text="Only page")
+        pdf_text = PDFText(pages=(page,), full_text="Only page")
+        assert pdf_text.full_text == "Only page"
+
+
+class TestPDFTable:
+    """Tests for PDFTable frozen dataclass."""
+
+    def test_construction_with_none_cells(self) -> None:
+        table = PDFTable(
+            page_number=3,
+            rows=(
+                ("Header A", "Header B", None),
+                ("cell 1", None, "cell 3"),
+            ),
+        )
+        assert table.page_number == 3
+        assert table.rows[0] == ("Header A", "Header B", None)
+        assert table.rows[1][1] is None
+
+    def test_frozen(self) -> None:
+        table = PDFTable(page_number=1, rows=(("a", "b"),))
+        with pytest.raises(FrozenInstanceError):
+            table.page_number = 2  # type: ignore[misc]
+
+
+class TestPDFTables:
+    """Tests for PDFTables frozen dataclass."""
+
+    def test_construction(self) -> None:
+        table_one = PDFTable(page_number=1, rows=(("x", "y"),))
+        table_two = PDFTable(page_number=2, rows=(("a", "b"),))
+        pdf_tables = PDFTables(tables=(table_one, table_two), total_tables=2)
+        assert len(pdf_tables.tables) == 2
+        assert pdf_tables.total_tables == 2
+
+    def test_total_tables_attribute(self) -> None:
+        pdf_tables = PDFTables(tables=(), total_tables=0)
+        assert pdf_tables.total_tables == 0
+
+
+class TestOCRResult:
+    """Tests for OCRResult frozen dataclass."""
+
+    def test_construction_with_confidence(self) -> None:
+        result = OCRResult(
+            text="Extracted text",
+            engine_name="tesseract",
+            preprocessed=True,
+            confidence=0.95,
+        )
+        assert result.text == "Extracted text"
+        assert result.engine_name == "tesseract"
+        assert result.preprocessed is True
+        assert result.confidence == 0.95
+
+    def test_frozen(self) -> None:
+        result = OCRResult(text="abc", engine_name="paddle", preprocessed=False, confidence=0.8)
+        with pytest.raises(FrozenInstanceError):
+            result.confidence = 0.5  # type: ignore[misc]
+
+
+class TestProcessingError:
+    """Tests for ProcessingError base exception."""
+
+    def test_message_attribute(self) -> None:
+        error = ProcessingError("Something failed")
+        assert error.message == "Something failed"
+
+    def test_source_path_defaults_to_empty(self) -> None:
+        error = ProcessingError("fail")
+        assert error.source_path == ""
+
+    def test_str_format_without_source_path(self) -> None:
+        error = ProcessingError("extraction failed")
+        assert "Processing error:" in str(error)
+        assert "extraction failed" in str(error)
+
+    def test_str_format_with_source_path(self) -> None:
+        error = ProcessingError("parse error", source_path="/tmp/doc.pdf")
+        error_string = str(error)
+        assert "Processing error:" in error_string
+        assert "(file: /tmp/doc.pdf)" in error_string
+
+    def test_is_exception(self) -> None:
+        assert isinstance(ProcessingError("msg"), Exception)
+
+    def test_can_be_raised_and_caught(self) -> None:
+        with pytest.raises(ProcessingError, match="Processing error"):
+            raise ProcessingError("broken")
+
+
+class TestPDFExtractionError:
+    """Tests for PDFExtractionError exception."""
+
+    def test_isinstance_processing_error(self) -> None:
+        error = PDFExtractionError("table extraction failed")
+        assert isinstance(error, ProcessingError)
+
+    def test_inherits_message_format(self) -> None:
+        error = PDFExtractionError("bad table", source_path="/data/file.pdf")
+        assert "Processing error:" in str(error)
+        assert "(file: /data/file.pdf)" in str(error)
+
+
+class TestOCRError:
+    """Tests for OCRError exception."""
+
+    def test_isinstance_processing_error(self) -> None:
+        error = OCRError("OCR engine crashed")
+        assert isinstance(error, ProcessingError)
+
+    def test_inherits_message_format(self) -> None:
+        error = OCRError("engine timeout", source_path="/images/scan.png")
+        assert "Processing error:" in str(error)
+        assert "(file: /images/scan.png)" in str(error)
+
+
+class TestPreprocessingError:
+    """Tests for PreprocessingError exception."""
+
+    def test_isinstance_processing_error(self) -> None:
+        error = PreprocessingError("deskew failed")
+        assert isinstance(error, ProcessingError)
+
+    def test_inherits_message_format(self) -> None:
+        error = PreprocessingError("grayscale conversion failed", source_path="/tmp/image.tiff")
+        assert "Processing error:" in str(error)
+        assert "(file: /tmp/image.tiff)" in str(error)

--- a/tests/unit/processing/test_ocr.py
+++ b/tests/unit/processing/test_ocr.py
@@ -1,0 +1,226 @@
+"""Tests for OCREngine ABC, TesseractEngine, and extract_text_ocr convenience function."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from data_collector.processing.models import OCRError, OCRResult
+from data_collector.processing.ocr import OCREngine, TesseractEngine, extract_text_ocr
+
+
+def _make_test_image() -> Image.Image:
+    """Create a minimal 100x100 RGB PIL Image for testing."""
+    return Image.fromarray(np.zeros((100, 100, 3), dtype=np.uint8))
+
+
+class TestOCREngineAbstract:
+    """Tests for OCREngine as an abstract base class."""
+
+    def test_cannot_instantiate(self) -> None:
+        with pytest.raises(TypeError):
+            OCREngine()  # type: ignore[abstract]
+
+    def test_subclass_must_implement_methods(self) -> None:
+        class IncompleteEngine(OCREngine):
+            """Subclass missing required abstract methods."""
+
+            @property
+            def engine_name(self) -> str:
+                return "incomplete"
+
+        with pytest.raises(TypeError):
+            IncompleteEngine()  # type: ignore[abstract]
+
+
+class TestTesseractEngine:
+    """Tests for TesseractEngine with mocked pytesseract."""
+
+    @patch("data_collector.processing.ocr.pytesseract")
+    def test_engine_name(self, mock_pytesseract: MagicMock) -> None:
+        engine = TesseractEngine()
+        assert engine.engine_name == "tesseract"
+
+    @patch("data_collector.processing.ocr.pytesseract")
+    def test_basic_extraction(self, mock_pytesseract: MagicMock) -> None:
+        mock_pytesseract.image_to_string.return_value = "Hello World"
+        mock_pytesseract.image_to_data.return_value = {"conf": [95]}
+        mock_pytesseract.Output.DICT = "dict"
+
+        engine = TesseractEngine()
+        result = engine.extract_text(_make_test_image())
+
+        assert result.text == "Hello World"
+        assert isinstance(result, OCRResult)
+
+    @patch("data_collector.processing.ocr.pytesseract")
+    def test_language_parameter(self, mock_pytesseract: MagicMock) -> None:
+        mock_pytesseract.image_to_string.return_value = "Tekst"
+        mock_pytesseract.image_to_data.return_value = {"conf": [90]}
+        mock_pytesseract.Output.DICT = "dict"
+
+        engine = TesseractEngine(language="eng+hrv")
+        test_image = _make_test_image()
+        engine.extract_text(test_image)
+
+        mock_pytesseract.image_to_string.assert_called_once_with(test_image, lang="eng+hrv")
+
+    @patch("data_collector.processing.ocr.pytesseract")
+    def test_tesseract_not_found_raises_ocr_error(self, mock_pytesseract: MagicMock) -> None:
+        mock_pytesseract.TesseractNotFoundError = type("TesseractNotFoundError", (Exception,), {})
+        mock_pytesseract.image_to_string.side_effect = mock_pytesseract.TesseractNotFoundError("not found")
+
+        engine = TesseractEngine()
+        with pytest.raises(OCRError, match="Tesseract binary not found"):
+            engine.extract_text(_make_test_image())
+
+    @patch("data_collector.processing.ocr.pytesseract")
+    def test_tesseract_error_raises_ocr_error(self, mock_pytesseract: MagicMock) -> None:
+        mock_pytesseract.TesseractError = type("TesseractError", (Exception,), {})
+        mock_pytesseract.TesseractNotFoundError = type("TesseractNotFoundError", (Exception,), {})
+        mock_pytesseract.image_to_string.side_effect = mock_pytesseract.TesseractError("bad image")
+
+        engine = TesseractEngine()
+        with pytest.raises(OCRError, match="Tesseract extraction failed"):
+            engine.extract_text(_make_test_image())
+
+    @patch("data_collector.processing.ocr.pytesseract")
+    def test_confidence_extraction(self, mock_pytesseract: MagicMock) -> None:
+        mock_pytesseract.image_to_string.return_value = "Some text"
+        mock_pytesseract.image_to_data.return_value = {"conf": [95, 87, -1, 92]}
+        mock_pytesseract.Output.DICT = "dict"
+
+        engine = TesseractEngine()
+        result = engine.extract_text(_make_test_image())
+
+        expected_confidence = (95 + 87 + 92) / (3 * 100)
+        assert result.confidence == pytest.approx(expected_confidence)
+
+    @patch("data_collector.processing.ocr.pytesseract")
+    def test_preprocessing_integration(self, mock_pytesseract: MagicMock) -> None:
+        mock_pytesseract.image_to_string.return_value = "Preprocessed text"
+        mock_pytesseract.image_to_data.return_value = {"conf": [90]}
+        mock_pytesseract.Output.DICT = "dict"
+
+        mock_preprocessor = MagicMock()
+        mock_preprocessor.run.return_value = _make_test_image()
+
+        engine = TesseractEngine(preprocessor=mock_preprocessor)
+        result = engine.extract_text(_make_test_image())
+
+        mock_preprocessor.run.assert_called_once()
+        assert result.preprocessed is True
+
+    @patch("data_collector.processing.ocr.pytesseract")
+    def test_no_preprocessing(self, mock_pytesseract: MagicMock) -> None:
+        mock_pytesseract.image_to_string.return_value = "Raw text"
+        mock_pytesseract.image_to_data.return_value = {"conf": [80]}
+        mock_pytesseract.Output.DICT = "dict"
+
+        engine = TesseractEngine()
+        result = engine.extract_text(_make_test_image())
+
+        assert result.preprocessed is False
+
+
+class TestExtractTextOcr:
+    """Tests for the extract_text_ocr convenience function."""
+
+    @patch("data_collector.processing.ocr.PaddleOCREngine")
+    def test_default_engine_is_paddleocr(self, mock_paddle_engine_class: MagicMock) -> None:
+        mock_engine_instance = MagicMock()
+        mock_engine_instance.engine_name = "paddleocr"
+        mock_engine_instance.extract_text.return_value = OCRResult(
+            text="paddle output", engine_name="paddleocr", preprocessed=False, confidence=0.9
+        )
+        mock_paddle_engine_class.return_value = mock_engine_instance
+
+        result = extract_text_ocr(_make_test_image())
+
+        mock_paddle_engine_class.assert_called_once()
+        assert result.text == "paddle output"
+
+    def test_custom_engine(self) -> None:
+        mock_engine = MagicMock()
+        mock_engine.extract_text.return_value = OCRResult(
+            text="custom output", engine_name="custom", preprocessed=False, confidence=0.85
+        )
+
+        result = extract_text_ocr(_make_test_image(), engine=mock_engine)
+
+        mock_engine.extract_text.assert_called_once()
+        assert result.text == "custom output"
+
+    @patch("data_collector.processing.ocr.Image")
+    def test_file_path_opens_image(self, mock_image_module: MagicMock) -> None:
+        mock_opened_image = MagicMock(spec=Image.Image)
+        mock_image_module.open.return_value = mock_opened_image
+
+        mock_engine = MagicMock()
+        mock_engine.extract_text.return_value = OCRResult(
+            text="from file", engine_name="mock", preprocessed=False, confidence=0.9
+        )
+
+        extract_text_ocr("/path/to/image.png", engine=mock_engine)
+
+        mock_image_module.open.assert_called_once()
+
+    @patch("data_collector.processing.ocr.Image")
+    def test_file_not_found_raises_ocr_error(self, mock_image_module: MagicMock) -> None:
+        mock_image_module.open.side_effect = FileNotFoundError("No such file")
+
+        mock_engine = MagicMock()
+
+        with pytest.raises(OCRError, match="Cannot open image"):
+            extract_text_ocr("/nonexistent/image.png", engine=mock_engine)
+
+    @patch("data_collector.processing.ocr.Image")
+    def test_extract_text_ocr_with_path_object(self, mock_image_module: MagicMock) -> None:
+        """7.1.12: Passing a Path object (not str) to extract_text_ocr calls Image.open."""
+        mock_opened_image = MagicMock(spec=Image.Image)
+        mock_image_module.open.return_value = mock_opened_image
+
+        mock_engine = MagicMock()
+        mock_engine.extract_text.return_value = OCRResult(
+            text="from path object", engine_name="mock", preprocessed=False, confidence=0.9
+        )
+
+        extract_text_ocr(Path("/path/to/image.png"), engine=mock_engine)
+
+        mock_image_module.open.assert_called_once()
+
+
+class TestTesseractConfidence:
+    """Tests for Tesseract confidence edge cases."""
+
+    @patch("data_collector.processing.ocr.pytesseract")
+    def test_tesseract_confidence_failure_returns_zero(self, mock_pytesseract: MagicMock) -> None:
+        """7.1.10: When image_to_data raises RuntimeError, confidence returns 0.0."""
+        mock_pytesseract.image_to_string.return_value = "Some text"
+        mock_pytesseract.image_to_data.side_effect = RuntimeError("data extraction failed")
+        mock_pytesseract.Output.DICT = "dict"
+        mock_pytesseract.TesseractNotFoundError = type("TesseractNotFoundError", (Exception,), {})
+        mock_pytesseract.TesseractError = type("TesseractError", (Exception,), {})
+
+        engine = TesseractEngine()
+        result = engine.extract_text(_make_test_image())
+
+        assert result.confidence == 0.0
+
+    @patch("data_collector.processing.ocr.pytesseract")
+    def test_tesseract_confidence_all_negative_one(self, mock_pytesseract: MagicMock) -> None:
+        """7.1.11: When all confidence values are -1, confidence returns 0.0."""
+        mock_pytesseract.image_to_string.return_value = "Text"
+        mock_pytesseract.image_to_data.return_value = {"conf": [-1, -1, -1]}
+        mock_pytesseract.Output.DICT = "dict"
+        mock_pytesseract.TesseractNotFoundError = type("TesseractNotFoundError", (Exception,), {})
+        mock_pytesseract.TesseractError = type("TesseractError", (Exception,), {})
+
+        engine = TesseractEngine()
+        result = engine.extract_text(_make_test_image())
+
+        assert result.confidence == 0.0

--- a/tests/unit/processing/test_paddle_ocr.py
+++ b/tests/unit/processing/test_paddle_ocr.py
@@ -1,0 +1,158 @@
+"""Tests for PaddleOCREngine with mocked PaddleOCR library."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from data_collector.processing.models import OCRError, OCRResult
+from data_collector.processing.ocr import PaddleOCREngine, extract_text_ocr
+
+
+def _make_test_image() -> Image.Image:
+    """Create a minimal 100x100 RGB PIL Image for testing."""
+    return Image.fromarray(np.zeros((100, 100, 3), dtype=np.uint8))
+
+
+def _make_paddle_result(lines: list[tuple[str, float]]) -> list[list[list[object]]]:
+    """Build a PaddleOCR-shaped result from (text, confidence) pairs.
+
+    PaddleOCR returns::
+
+        [
+            [  # page/image
+                [[[x1,y1],[x2,y2],[x3,y3],[x4,y4]], ("text", confidence)],
+                ...
+            ]
+        ]
+
+    Args:
+        lines: List of (text, confidence) tuples.
+
+    Returns:
+        Nested list matching PaddleOCR output structure.
+    """
+    dummy_bounding_box = [[0, 0], [100, 0], [100, 30], [0, 30]]
+    page: list[list[object]] = []
+    for text, confidence in lines:
+        page.append([dummy_bounding_box, (text, confidence)])
+    return [page]
+
+
+class TestPaddleOCREngine:
+    """Tests for PaddleOCREngine with mocked PaddleOCR."""
+
+    @patch("data_collector.processing.ocr.PaddleOCR")
+    def test_engine_name(self, mock_paddle_class: MagicMock) -> None:
+        engine = PaddleOCREngine()
+        assert engine.engine_name == "paddleocr"
+
+    @patch("data_collector.processing.ocr.PaddleOCR")
+    def test_engine_init_creates_paddleocr(self, mock_paddle_class: MagicMock) -> None:
+        PaddleOCREngine()
+        mock_paddle_class.assert_called_once_with(use_angle_cls=True, lang="en", show_log=False)
+
+    @patch("data_collector.processing.ocr.PaddleOCR")
+    def test_custom_language(self, mock_paddle_class: MagicMock) -> None:
+        PaddleOCREngine(language="hr")
+        mock_paddle_class.assert_called_once_with(use_angle_cls=True, lang="hr", show_log=False)
+
+    @patch("data_collector.processing.ocr.PaddleOCR")
+    def test_basic_extraction(self, mock_paddle_class: MagicMock) -> None:
+        paddle_result = _make_paddle_result([("Hello World", 0.95), ("Second line", 0.88)])
+        mock_ocr_instance = MagicMock()
+        mock_ocr_instance.ocr.return_value = paddle_result
+        mock_paddle_class.return_value = mock_ocr_instance
+
+        engine = PaddleOCREngine()
+        result = engine.extract_text(_make_test_image())
+
+        assert result.text == "Hello World\nSecond line"
+        assert isinstance(result, OCRResult)
+        assert result.engine_name == "paddleocr"
+
+    @patch("data_collector.processing.ocr.PaddleOCR")
+    def test_empty_result_none(self, mock_paddle_class: MagicMock) -> None:
+        mock_ocr_instance = MagicMock()
+        mock_ocr_instance.ocr.return_value = [None]
+        mock_paddle_class.return_value = mock_ocr_instance
+
+        engine = PaddleOCREngine()
+        result = engine.extract_text(_make_test_image())
+
+        assert result.text == ""
+
+    @patch("data_collector.processing.ocr.PaddleOCR")
+    def test_empty_result_empty_list(self, mock_paddle_class: MagicMock) -> None:
+        mock_ocr_instance = MagicMock()
+        mock_ocr_instance.ocr.return_value = [[]]
+        mock_paddle_class.return_value = mock_ocr_instance
+
+        engine = PaddleOCREngine()
+        result = engine.extract_text(_make_test_image())
+
+        assert result.text == ""
+
+    @patch("data_collector.processing.ocr.PaddleOCR")
+    def test_confidence_average(self, mock_paddle_class: MagicMock) -> None:
+        paddle_result = _make_paddle_result([("Hello World", 0.95), ("Second line", 0.88)])
+        mock_ocr_instance = MagicMock()
+        mock_ocr_instance.ocr.return_value = paddle_result
+        mock_paddle_class.return_value = mock_ocr_instance
+
+        engine = PaddleOCREngine()
+        result = engine.extract_text(_make_test_image())
+
+        expected_confidence = (0.95 + 0.88) / 2
+        assert result.confidence == pytest.approx(expected_confidence)
+
+    @patch("data_collector.processing.ocr.PaddleOCR")
+    def test_confidence_empty_result(self, mock_paddle_class: MagicMock) -> None:
+        mock_ocr_instance = MagicMock()
+        mock_ocr_instance.ocr.return_value = [None]
+        mock_paddle_class.return_value = mock_ocr_instance
+
+        engine = PaddleOCREngine()
+        result = engine.extract_text(_make_test_image())
+
+        assert result.confidence == 0.0
+
+    @patch("data_collector.processing.ocr.PaddleOCR")
+    def test_extraction_error_wrapped(self, mock_paddle_class: MagicMock) -> None:
+        mock_ocr_instance = MagicMock()
+        mock_ocr_instance.ocr.side_effect = RuntimeError("PaddleOCR internal failure")
+        mock_paddle_class.return_value = mock_ocr_instance
+
+        engine = PaddleOCREngine()
+        with pytest.raises(OCRError, match="PaddleOCR extraction failed"):
+            engine.extract_text(_make_test_image())
+
+    @patch("data_collector.processing.ocr.PaddleOCREngine")
+    def test_default_in_extract_text_ocr(self, mock_paddle_engine_class: MagicMock) -> None:
+        mock_engine_instance = MagicMock()
+        mock_engine_instance.engine_name = "paddleocr"
+        mock_engine_instance.extract_text.return_value = OCRResult(
+            text="default engine output", engine_name="paddleocr", preprocessed=False, confidence=0.92
+        )
+        mock_paddle_engine_class.return_value = mock_engine_instance
+
+        result = extract_text_ocr(_make_test_image())
+
+        mock_paddle_engine_class.assert_called_once()
+        assert result.engine_name == "paddleocr"
+
+    @patch("data_collector.processing.ocr.PaddleOCR")
+    def test_empty_result_bare_none(self, mock_paddle_class: MagicMock) -> None:
+        """7.4.2: When ocr.ocr() returns None (not [None]), text is empty and confidence is 0.0."""
+        mock_ocr_instance = MagicMock()
+        mock_ocr_instance.ocr.return_value = None
+        mock_paddle_class.return_value = mock_ocr_instance
+
+        engine = PaddleOCREngine()
+        result = engine.extract_text(_make_test_image())
+
+        assert result.text == ""
+        assert result.confidence == 0.0

--- a/tests/unit/processing/test_pdf.py
+++ b/tests/unit/processing/test_pdf.py
@@ -1,0 +1,333 @@
+"""Unit tests for PDF classification, text extraction, and table extraction."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from data_collector.enums.processing import PdfDataType
+from data_collector.processing.models import PDFExtractionError
+from data_collector.processing.pdf import classify_pdf, extract_tables_pdfplumber, extract_text_pdfplumber
+
+MODULE = "data_collector.processing.pdf"
+
+
+def _make_mock_pdf(
+    pages_text: list[str | None],
+    pages_tables: list[list[list[list[Any]]]] | None = None,
+) -> MagicMock:
+    """Create a mock pdfplumber PDF context manager.
+
+    Args:
+        pages_text: Text returned by each page's extract_text(). None means no text.
+        pages_tables: Per-page list of tables. Each table is a list of rows (list of cells).
+    """
+    mock_pdf = MagicMock()
+    mock_pages: list[MagicMock] = []
+    for index, text in enumerate(pages_text):
+        page = MagicMock()
+        page.extract_text.return_value = text
+        tables = pages_tables[index] if pages_tables and index < len(pages_tables) else []
+        page.extract_tables.return_value = tables
+        mock_pages.append(page)
+    mock_pdf.pages = mock_pages
+    mock_pdf.__enter__ = MagicMock(return_value=mock_pdf)
+    mock_pdf.__exit__ = MagicMock(return_value=False)
+    return mock_pdf
+
+
+def _long_text(length: int = 60) -> str:
+    """Return a string of the given length for page text simulation."""
+    return "A" * length
+
+
+class TestClassifyPdf:
+    """Tests for the classify_pdf function."""
+
+    @patch(f"{MODULE}.pdfplumber")
+    def test_all_text_pages(self, mock_pdfplumber: MagicMock) -> None:
+        """10 pages all with sufficient text -> PdfDataType.TEXT."""
+        mock_pdfplumber.open.return_value = _make_mock_pdf([_long_text()] * 10)
+
+        result = classify_pdf("test.pdf")
+
+        assert result.document_type == PdfDataType.TEXT
+        assert result.total_pages == 10
+        assert result.text_pages == 10
+        assert result.text_ratio == 1.0
+
+    @patch(f"{MODULE}.pdfplumber")
+    def test_all_image_pages(self, mock_pdfplumber: MagicMock) -> None:
+        """10 pages all with None/empty text -> PdfDataType.IMAGE."""
+        mock_pdfplumber.open.return_value = _make_mock_pdf([None] * 10)
+
+        result = classify_pdf("test.pdf")
+
+        assert result.document_type == PdfDataType.IMAGE
+        assert result.total_pages == 10
+        assert result.text_pages == 0
+        assert result.text_ratio == 0.0
+
+    @patch(f"{MODULE}.pdfplumber")
+    def test_threshold_boundary_exactly_90_percent(self, mock_pdfplumber: MagicMock) -> None:
+        """9 of 10 pages have text (0.9 >= 0.9 threshold) -> TEXT."""
+        pages = [_long_text()] * 9 + [None]
+        mock_pdfplumber.open.return_value = _make_mock_pdf(pages)
+
+        result = classify_pdf("test.pdf")
+
+        assert result.document_type == PdfDataType.TEXT
+        assert result.text_ratio == 0.9
+
+    @patch(f"{MODULE}.pdfplumber")
+    def test_threshold_boundary_below(self, mock_pdfplumber: MagicMock) -> None:
+        """8 of 10 pages have text (0.8 < 0.9 threshold) -> IMAGE."""
+        pages = [_long_text()] * 8 + [None, None]
+        mock_pdfplumber.open.return_value = _make_mock_pdf(pages)
+
+        result = classify_pdf("test.pdf")
+
+        assert result.document_type == PdfDataType.IMAGE
+        assert result.text_ratio == 0.8
+
+    @patch(f"{MODULE}.pdfplumber")
+    def test_empty_pdf_zero_pages(self, mock_pdfplumber: MagicMock) -> None:
+        """PDF with zero pages -> IMAGE with 0.0 ratio."""
+        mock_pdfplumber.open.return_value = _make_mock_pdf([])
+
+        result = classify_pdf("test.pdf")
+
+        assert result.document_type == PdfDataType.IMAGE
+        assert result.total_pages == 0
+        assert result.text_pages == 0
+        assert result.text_ratio == 0.0
+
+    @patch(f"{MODULE}.pdfplumber")
+    def test_single_page_with_text(self, mock_pdfplumber: MagicMock) -> None:
+        """Single page with text -> TEXT (1/1 = 1.0 >= 0.9)."""
+        mock_pdfplumber.open.return_value = _make_mock_pdf([_long_text()])
+
+        result = classify_pdf("test.pdf")
+
+        assert result.document_type == PdfDataType.TEXT
+        assert result.total_pages == 1
+        assert result.text_pages == 1
+
+    @patch(f"{MODULE}.pdfplumber")
+    def test_min_text_length_filtering(self, mock_pdfplumber: MagicMock) -> None:
+        """Page with short text (<50 chars) is treated as no text."""
+        short_text = "A" * 30
+        mock_pdfplumber.open.return_value = _make_mock_pdf([short_text])
+
+        result = classify_pdf("test.pdf", min_text_length=50)
+
+        assert result.document_type == PdfDataType.IMAGE
+        assert result.text_pages == 0
+
+    @patch(f"{MODULE}.pdfplumber")
+    def test_custom_threshold(self, mock_pdfplumber: MagicMock) -> None:
+        """With threshold=0.5, 5/10 pages with text -> TEXT."""
+        pages = [_long_text()] * 5 + [None] * 5
+        mock_pdfplumber.open.return_value = _make_mock_pdf(pages)
+
+        result = classify_pdf("test.pdf", threshold=0.5)
+
+        assert result.document_type == PdfDataType.TEXT
+        assert result.text_ratio == 0.5
+
+    @patch(f"{MODULE}.pdfplumber")
+    def test_pdfplumber_error_wrapped(self, mock_pdfplumber: MagicMock) -> None:
+        """Exception from pdfplumber.open is wrapped in PDFExtractionError."""
+        mock_pdfplumber.open.side_effect = RuntimeError("corrupt file")
+
+        with pytest.raises(PDFExtractionError, match="Failed to classify PDF"):
+            classify_pdf("bad.pdf")
+
+
+class TestExtractTextPdfplumber:
+    """Tests for the extract_text_pdfplumber function."""
+
+    @patch(f"{MODULE}.pdfplumber")
+    def test_all_pages(self, mock_pdfplumber: MagicMock) -> None:
+        """Extract all pages and verify page count and full_text."""
+        mock_pdfplumber.open.return_value = _make_mock_pdf(["Page one.", "Page two.", "Page three."])
+
+        result = extract_text_pdfplumber("test.pdf")
+
+        assert len(result.pages) == 3
+        assert result.pages[0].page_number == 1
+        assert result.pages[0].text == "Page one."
+        assert result.pages[2].text == "Page three."
+        assert "Page one." in result.full_text
+        assert "Page three." in result.full_text
+
+    @patch(f"{MODULE}.pdfplumber")
+    def test_specific_page_numbers(self, mock_pdfplumber: MagicMock) -> None:
+        """Extract only pages 1 and 3 from a 3-page PDF."""
+        mock_pdfplumber.open.return_value = _make_mock_pdf(["First", "Second", "Third"])
+
+        result = extract_text_pdfplumber("test.pdf", page_numbers=[1, 3])
+
+        assert len(result.pages) == 2
+        assert result.pages[0].page_number == 1
+        assert result.pages[0].text == "First"
+        assert result.pages[1].page_number == 3
+        assert result.pages[1].text == "Third"
+
+    @patch(f"{MODULE}.pdfplumber")
+    def test_page_with_no_text(self, mock_pdfplumber: MagicMock) -> None:
+        """Page returning None -> empty string in PageText."""
+        mock_pdfplumber.open.return_value = _make_mock_pdf([None])
+
+        result = extract_text_pdfplumber("test.pdf")
+
+        assert len(result.pages) == 1
+        assert result.pages[0].text == ""
+
+    @patch(f"{MODULE}.pdfplumber")
+    def test_full_text_joined_by_newline(self, mock_pdfplumber: MagicMock) -> None:
+        """Verify full_text is pages joined by newline."""
+        mock_pdfplumber.open.return_value = _make_mock_pdf(["Alpha", "Beta"])
+
+        result = extract_text_pdfplumber("test.pdf")
+
+        assert result.full_text == "Alpha\nBeta"
+
+    @patch(f"{MODULE}.pdfplumber")
+    def test_invalid_page_number_zero(self, mock_pdfplumber: MagicMock) -> None:
+        """Page number 0 is out of range -> PDFExtractionError."""
+        mock_pdfplumber.open.return_value = _make_mock_pdf(["Some text."])
+
+        with pytest.raises(PDFExtractionError, match="out of range"):
+            extract_text_pdfplumber("test.pdf", page_numbers=[0])
+
+    @patch(f"{MODULE}.pdfplumber")
+    def test_invalid_page_number_beyond_total(self, mock_pdfplumber: MagicMock) -> None:
+        """Page number beyond total pages -> PDFExtractionError."""
+        mock_pdfplumber.open.return_value = _make_mock_pdf(["Some text."])
+
+        with pytest.raises(PDFExtractionError, match="out of range"):
+            extract_text_pdfplumber("test.pdf", page_numbers=[999])
+
+
+class TestExtractTablesPdfplumber:
+    """Tests for the extract_tables_pdfplumber function."""
+
+    @patch(f"{MODULE}.pdfplumber")
+    def test_pages_with_tables(self, mock_pdfplumber: MagicMock) -> None:
+        """Verify PDFTables contains extracted tables with correct structure."""
+        table_data = [[["Name", "Age"], ["Alice", "30"]]]
+        mock_pdfplumber.open.return_value = _make_mock_pdf(
+            pages_text=["text"],
+            pages_tables=[table_data],
+        )
+
+        result = extract_tables_pdfplumber("test.pdf")
+
+        assert result.total_tables == 1
+        assert len(result.tables) == 1
+        assert result.tables[0].page_number == 1
+        assert result.tables[0].rows == (("Name", "Age"), ("Alice", "30"))
+
+    @patch(f"{MODULE}.pdfplumber")
+    def test_no_tables(self, mock_pdfplumber: MagicMock) -> None:
+        """Pages with no tables -> PDFTables with empty tuple."""
+        mock_pdfplumber.open.return_value = _make_mock_pdf(
+            pages_text=["text", "more text"],
+            pages_tables=[[], []],
+        )
+
+        result = extract_tables_pdfplumber("test.pdf")
+
+        assert result.total_tables == 0
+        assert result.tables == ()
+
+    @patch(f"{MODULE}.pdfplumber")
+    def test_none_cells_in_table(self, mock_pdfplumber: MagicMock) -> None:
+        """Table with None cell values preserved in output."""
+        table_with_nones = [[["Header", None], [None, "Value"]]]
+        mock_pdfplumber.open.return_value = _make_mock_pdf(
+            pages_text=["text"],
+            pages_tables=[table_with_nones],
+        )
+
+        result = extract_tables_pdfplumber("test.pdf")
+
+        assert result.total_tables == 1
+        assert result.tables[0].rows == (("Header", None), (None, "Value"))
+
+    @patch(f"{MODULE}.pdfplumber")
+    def test_custom_table_settings(self, mock_pdfplumber: MagicMock) -> None:
+        """Verify table_settings dict is passed through to extract_tables()."""
+        mock_pdf = _make_mock_pdf(pages_text=["text"], pages_tables=[[]])
+        mock_pdfplumber.open.return_value = mock_pdf
+
+        custom_settings: dict[str, object] = {"vertical_strategy": "text", "horizontal_strategy": "text"}
+        extract_tables_pdfplumber("test.pdf", table_settings=custom_settings)
+
+        mock_pdf.pages[0].extract_tables.assert_called_once_with(custom_settings)
+
+    @patch(f"{MODULE}.pdfplumber")
+    def test_extract_tables_invalid_page_number_zero(self, mock_pdfplumber: MagicMock) -> None:
+        """7.2.2: Page number 0 for extract_tables raises PDFExtractionError."""
+        mock_pdfplumber.open.return_value = _make_mock_pdf(
+            pages_text=["text"],
+            pages_tables=[[[["A", "B"]]]],
+        )
+
+        with pytest.raises(PDFExtractionError, match="out of range"):
+            extract_tables_pdfplumber("test.pdf", page_numbers=[0])
+
+
+class TestExtractTextZeroPages:
+    """Tests for edge cases with zero-page PDFs."""
+
+    @patch(f"{MODULE}.pdfplumber")
+    def test_extract_text_zero_pages(self, mock_pdfplumber: MagicMock) -> None:
+        """7.1.7: PDF with 0 pages returns PDFText with empty pages tuple and empty full_text."""
+        mock_pdfplumber.open.return_value = _make_mock_pdf([])
+
+        result = extract_text_pdfplumber("empty.pdf")
+
+        assert result.pages == ()
+        assert result.full_text == ""
+
+    @patch(f"{MODULE}.pdfplumber")
+    def test_extract_tables_zero_pages(self, mock_pdfplumber: MagicMock) -> None:
+        """7.1.7: PDF with 0 pages returns PDFTables with empty tables and zero total."""
+        mock_pdfplumber.open.return_value = _make_mock_pdf([])
+
+        result = extract_tables_pdfplumber("empty.pdf")
+
+        assert result.tables == ()
+        assert result.total_tables == 0
+
+
+class TestPdfplumberErrorWrapping:
+    """Tests for error wrapping in extraction functions."""
+
+    @patch(f"{MODULE}.pdfplumber")
+    def test_extract_text_pdfplumber_error_wrapped(self, mock_pdfplumber: MagicMock) -> None:
+        """7.1.8: Exception from pdfplumber.open in extract_text is wrapped in PDFExtractionError."""
+        mock_pdfplumber.open.side_effect = RuntimeError("corrupt PDF data")
+
+        with pytest.raises(PDFExtractionError, match="Failed to extract text from PDF"):
+            extract_text_pdfplumber("corrupt.pdf")
+
+    @patch(f"{MODULE}.pdfplumber")
+    def test_extract_tables_pdfplumber_error_wrapped(self, mock_pdfplumber: MagicMock) -> None:
+        """7.1.8: Exception from pdfplumber.open in extract_tables is wrapped in PDFExtractionError."""
+        mock_pdfplumber.open.side_effect = RuntimeError("corrupt PDF data")
+
+        with pytest.raises(PDFExtractionError, match="Failed to extract tables from PDF"):
+            extract_tables_pdfplumber("corrupt.pdf")
+
+    @patch(f"{MODULE}.pdfplumber")
+    def test_invalid_negative_page_number(self, mock_pdfplumber: MagicMock) -> None:
+        """7.1.9: Negative page number raises PDFExtractionError."""
+        mock_pdfplumber.open.return_value = _make_mock_pdf(["Some text."])
+
+        with pytest.raises(PDFExtractionError, match="out of range"):
+            extract_text_pdfplumber("test.pdf", page_numbers=[-1])

--- a/tests/unit/processing/test_preprocessing.py
+++ b/tests/unit/processing/test_preprocessing.py
@@ -1,0 +1,303 @@
+"""Unit tests for ImagePreprocessor pipeline."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from data_collector.processing.models import PreprocessingError
+from data_collector.processing.preprocessing import ImagePreprocessor
+
+MODULE = "data_collector.processing.preprocessing"
+
+
+def _color_image() -> Image.Image:
+    """Create a small 100x100 RGB PIL Image for testing."""
+    return Image.fromarray(np.zeros((100, 100, 3), dtype=np.uint8))
+
+
+def _grayscale_image() -> Image.Image:
+    """Create a small 100x100 grayscale PIL Image for testing."""
+    return Image.fromarray(np.zeros((100, 100), dtype=np.uint8))
+
+
+def _gray_array() -> np.ndarray:  # type: ignore[type-arg]
+    """Return a 2D numpy array simulating a grayscale image."""
+    return np.zeros((100, 100), dtype=np.uint8)
+
+
+def _color_array() -> np.ndarray:  # type: ignore[type-arg]
+    """Return a 3D numpy array simulating a BGR image."""
+    return np.zeros((100, 100, 3), dtype=np.uint8)
+
+
+class TestImagePreprocessor:
+    """Tests for the ImagePreprocessor fixed-stage pipeline."""
+
+    @patch(f"{MODULE}.cv2")
+    def test_full_pipeline_runs_all_stages(self, mock_cv2: MagicMock) -> None:
+        """All stages enabled by default. Verify every cv2 function is called."""
+        gray = _gray_array()
+        # _pil_to_cv2 calls cvtColor(RGB2BGR) for 3-channel input, then grayscale calls cvtColor(BGR2GRAY)
+        mock_cv2.cvtColor.return_value = gray
+        mock_cv2.resize.return_value = gray
+        mock_cv2.fastNlMeansDenoising.return_value = gray
+        mock_cv2.createCLAHE.return_value.apply.return_value = gray
+        mock_cv2.threshold.return_value = (None, gray)
+        mock_cv2.findContours.return_value = ([], None)
+        mock_cv2.morphologyEx.return_value = gray
+        mock_cv2.copyMakeBorder.return_value = gray
+
+        preprocessor = ImagePreprocessor()
+        result = preprocessor.run(_color_image(), dpi=150)
+
+        assert isinstance(result, Image.Image)
+        mock_cv2.cvtColor.assert_called()
+        mock_cv2.resize.assert_called()
+        mock_cv2.fastNlMeansDenoising.assert_called()
+        mock_cv2.createCLAHE.assert_called()
+        mock_cv2.threshold.assert_called()
+        mock_cv2.morphologyEx.assert_called()
+        mock_cv2.copyMakeBorder.assert_called()
+
+    @patch(f"{MODULE}.cv2")
+    def test_selective_stage_disabling(self, mock_cv2: MagicMock) -> None:
+        """Disable grayscale, denoise, and border. Those cv2 functions must not be called."""
+        gray = _gray_array()
+        # _pil_to_cv2 still calls cvtColor for RGB->BGR
+        mock_cv2.cvtColor.return_value = gray
+        mock_cv2.resize.return_value = gray
+        mock_cv2.createCLAHE.return_value.apply.return_value = gray
+        mock_cv2.threshold.return_value = (None, gray)
+        mock_cv2.findContours.return_value = ([], None)
+        mock_cv2.morphologyEx.return_value = gray
+
+        preprocessor = ImagePreprocessor(grayscale=False, denoise=False, border=False)
+        preprocessor.run(_color_image(), dpi=150)
+
+        mock_cv2.fastNlMeansDenoising.assert_not_called()
+        mock_cv2.fastNlMeansDenoisingColored.assert_not_called()
+        mock_cv2.copyMakeBorder.assert_not_called()
+
+    @patch(f"{MODULE}.cv2")
+    def test_dpi_none_skips_upscale(self, mock_cv2: MagicMock) -> None:
+        """When dpi is None, cv2.resize must not be called."""
+        gray = _gray_array()
+        mock_cv2.cvtColor.return_value = gray
+        mock_cv2.fastNlMeansDenoising.return_value = gray
+        mock_cv2.createCLAHE.return_value.apply.return_value = gray
+        mock_cv2.threshold.return_value = (None, gray)
+        mock_cv2.findContours.return_value = ([], None)
+        mock_cv2.morphologyEx.return_value = gray
+        mock_cv2.copyMakeBorder.return_value = gray
+
+        preprocessor = ImagePreprocessor()
+        preprocessor.run(_color_image(), dpi=None)
+
+        mock_cv2.resize.assert_not_called()
+
+    @patch(f"{MODULE}.cv2")
+    def test_upscale_skipped_when_dpi_sufficient(self, mock_cv2: MagicMock) -> None:
+        """DPI at or above min_dpi means no resize needed."""
+        gray = _gray_array()
+        mock_cv2.cvtColor.return_value = gray
+        mock_cv2.fastNlMeansDenoising.return_value = gray
+        mock_cv2.createCLAHE.return_value.apply.return_value = gray
+        mock_cv2.threshold.return_value = (None, gray)
+        mock_cv2.findContours.return_value = ([], None)
+        mock_cv2.morphologyEx.return_value = gray
+        mock_cv2.copyMakeBorder.return_value = gray
+
+        preprocessor = ImagePreprocessor(min_dpi=300)
+        preprocessor.run(_color_image(), dpi=400)
+
+        mock_cv2.resize.assert_not_called()
+
+    @patch(f"{MODULE}.cv2")
+    def test_upscale_applied_when_dpi_low(self, mock_cv2: MagicMock) -> None:
+        """DPI below min_dpi triggers cv2.resize."""
+        gray = _gray_array()
+        mock_cv2.cvtColor.return_value = gray
+        mock_cv2.resize.return_value = gray
+        mock_cv2.fastNlMeansDenoising.return_value = gray
+        mock_cv2.createCLAHE.return_value.apply.return_value = gray
+        mock_cv2.threshold.return_value = (None, gray)
+        mock_cv2.findContours.return_value = ([], None)
+        mock_cv2.morphologyEx.return_value = gray
+        mock_cv2.copyMakeBorder.return_value = gray
+
+        preprocessor = ImagePreprocessor(min_dpi=300)
+        preprocessor.run(_color_image(), dpi=150)
+
+        mock_cv2.resize.assert_called_once()
+
+    @patch(f"{MODULE}.cv2")
+    def test_clahe_params_forwarded(self, mock_cv2: MagicMock) -> None:
+        """Custom CLAHE parameters are forwarded to cv2.createCLAHE."""
+        gray = _gray_array()
+        mock_cv2.cvtColor.return_value = gray
+        mock_cv2.resize.return_value = gray
+        mock_cv2.fastNlMeansDenoising.return_value = gray
+        mock_cv2.createCLAHE.return_value.apply.return_value = gray
+        mock_cv2.threshold.return_value = (None, gray)
+        mock_cv2.findContours.return_value = ([], None)
+        mock_cv2.morphologyEx.return_value = gray
+        mock_cv2.copyMakeBorder.return_value = gray
+
+        preprocessor = ImagePreprocessor(clahe_clip_limit=3.0, clahe_tile_size=16)
+        preprocessor.run(_color_image(), dpi=150)
+
+        mock_cv2.createCLAHE.assert_called_once_with(clipLimit=3.0, tileGridSize=(16, 16))
+
+    @patch(f"{MODULE}.cv2")
+    def test_cv2_error_wrapped_in_preprocessing_error(self, mock_cv2: MagicMock) -> None:
+        """A cv2.error raised during processing is wrapped in PreprocessingError."""
+        mock_cv2.error = type("error", (Exception,), {})
+        mock_cv2.cvtColor.side_effect = mock_cv2.error("synthetic cv2 failure")
+
+        preprocessor = ImagePreprocessor()
+
+        with pytest.raises(PreprocessingError, match="OpenCV operation failed"):
+            preprocessor.run(_color_image(), dpi=150)
+
+    @patch(f"{MODULE}.cv2")
+    def test_grayscale_idempotent(self, mock_cv2: MagicMock) -> None:
+        """A 2D (already grayscale) image should not trigger cvtColor for grayscale conversion."""
+        gray = _gray_array()
+        mock_cv2.fastNlMeansDenoising.return_value = gray
+        mock_cv2.createCLAHE.return_value.apply.return_value = gray
+        mock_cv2.threshold.return_value = (None, gray)
+        mock_cv2.findContours.return_value = ([], None)
+        mock_cv2.morphologyEx.return_value = gray
+        mock_cv2.copyMakeBorder.return_value = gray
+
+        preprocessor = ImagePreprocessor()
+        preprocessor.run(_grayscale_image(), dpi=None)
+
+        # cvtColor should NOT be called because:
+        # - _pil_to_cv2 skips conversion for 2D arrays (no RGB2BGR needed)
+        # - _grayscale_image already has shape (100, 100) so _grayscale_image stage skips
+        mock_cv2.cvtColor.assert_not_called()
+
+    @patch(f"{MODULE}.cv2")
+    def test_color_denoising_branch(self, mock_cv2: MagicMock) -> None:
+        """7.1.1: With grayscale=False and denoise=True, fastNlMeansDenoisingColored is used."""
+        color = _color_array()
+        mock_cv2.cvtColor.return_value = color
+        mock_cv2.resize.return_value = color
+        mock_cv2.fastNlMeansDenoisingColored.return_value = color
+        mock_cv2.createCLAHE.return_value.apply.return_value = _gray_array()
+        mock_cv2.threshold.return_value = (None, _gray_array())
+        mock_cv2.findContours.return_value = ([], None)
+        mock_cv2.morphologyEx.return_value = _gray_array()
+        mock_cv2.copyMakeBorder.return_value = _gray_array()
+
+        preprocessor = ImagePreprocessor(grayscale=False, denoise=True)
+        preprocessor.run(_color_image(), dpi=150)
+
+        mock_cv2.fastNlMeansDenoisingColored.assert_called_once()
+        mock_cv2.fastNlMeansDenoising.assert_not_called()
+
+    @patch(f"{MODULE}.cv2")
+    def test_generic_exception_wrapped_in_preprocessing_error(self, mock_cv2: MagicMock) -> None:
+        """7.1.4: A generic RuntimeError is wrapped in PreprocessingError with unexpected message."""
+        mock_cv2.error = type("error", (Exception,), {})
+        mock_cv2.cvtColor.side_effect = RuntimeError("something went wrong")
+
+        preprocessor = ImagePreprocessor()
+
+        with pytest.raises(PreprocessingError, match="Unexpected preprocessing failure"):
+            preprocessor.run(_color_image(), dpi=150)
+
+    @patch(f"{MODULE}.cv2")
+    def test_deskew_with_significant_skew(self, mock_cv2: MagicMock) -> None:
+        """7.1.5: When angle > 0.5 degrees, getRotationMatrix2D and warpAffine are called."""
+        gray = _gray_array()
+        mock_cv2.cvtColor.return_value = gray
+        mock_cv2.resize.return_value = gray
+        mock_cv2.fastNlMeansDenoising.return_value = gray
+        mock_cv2.createCLAHE.return_value.apply.return_value = gray
+        mock_cv2.threshold.return_value = (None, gray)
+
+        # Create a mock contour with non-negligible area
+        mock_contour = MagicMock()
+        mock_cv2.findContours.return_value = ([mock_contour], None)
+        mock_cv2.contourArea.return_value = 5000
+        # minAreaRect returns ((cx, cy), (w, h), angle). Angle of 5.0 > 0.5 threshold
+        mock_cv2.minAreaRect.return_value = ((50, 50), (80, 40), 5.0)
+        mock_cv2.getRotationMatrix2D.return_value = np.eye(2, 3, dtype=np.float64)
+        mock_cv2.warpAffine.return_value = gray
+        mock_cv2.morphologyEx.return_value = gray
+        mock_cv2.copyMakeBorder.return_value = gray
+
+        preprocessor = ImagePreprocessor()
+        preprocessor.run(_color_image(), dpi=150)
+
+        mock_cv2.getRotationMatrix2D.assert_called_once()
+        mock_cv2.warpAffine.assert_called_once()
+
+    @patch(f"{MODULE}.cv2")
+    def test_contrast_enhancement_multichannel(self, mock_cv2: MagicMock) -> None:
+        """7.1.2: With grayscale=False and contrast=True, cvtColor is called inside _enhance_contrast."""
+        color = _color_array()
+        gray = _gray_array()
+        # _pil_to_cv2 calls cvtColor for RGB2BGR, then _enhance_contrast calls cvtColor for BGR2GRAY
+        mock_cv2.cvtColor.return_value = gray
+        mock_cv2.resize.return_value = color
+        mock_cv2.fastNlMeansDenoisingColored.return_value = color
+        mock_cv2.createCLAHE.return_value.apply.return_value = gray
+        mock_cv2.threshold.return_value = (None, gray)
+        mock_cv2.findContours.return_value = ([], None)
+        mock_cv2.morphologyEx.return_value = gray
+        mock_cv2.copyMakeBorder.return_value = gray
+
+        preprocessor = ImagePreprocessor(grayscale=False, contrast=True)
+        preprocessor.run(_color_image(), dpi=150)
+
+        # cvtColor should be called at least twice: once in _pil_to_cv2 (RGB2BGR) and
+        # once in _enhance_contrast (BGR2GRAY) for multi-channel input
+        assert mock_cv2.cvtColor.call_count >= 2
+        mock_cv2.createCLAHE.assert_called_once()
+
+    @patch(f"{MODULE}.cv2")
+    def test_pil_to_cv2_rgba_image(self, mock_cv2: MagicMock) -> None:
+        """7.1.6: _pil_to_cv2 handles a 4-channel RGBA image (no RGB2BGR conversion for channel!=3)."""
+        gray = _gray_array()
+        mock_cv2.cvtColor.return_value = gray
+        mock_cv2.fastNlMeansDenoising.return_value = gray
+        mock_cv2.createCLAHE.return_value.apply.return_value = gray
+        mock_cv2.threshold.return_value = (None, gray)
+        mock_cv2.findContours.return_value = ([], None)
+        mock_cv2.morphologyEx.return_value = gray
+        mock_cv2.copyMakeBorder.return_value = gray
+
+        # Create a 4-channel RGBA image. _pil_to_cv2 should NOT call cvtColor for RGB2BGR
+        # because the condition checks shape[2]==3, and RGBA has shape[2]==4.
+        rgba_array = np.zeros((100, 100, 4), dtype=np.uint8)
+        rgba_image = Image.fromarray(rgba_array, mode="RGBA")
+
+        preprocessor = ImagePreprocessor()
+        preprocessor.run(rgba_image, dpi=None)
+
+        # cvtColor should be called for grayscale conversion (BGR2GRAY) from the grayscale stage,
+        # but NOT for RGB2BGR in _pil_to_cv2 since shape[2]==4
+        # First call to cvtColor would be from _grayscale_image (not _pil_to_cv2)
+        for call_args in mock_cv2.cvtColor.call_args_list:
+            args = call_args[0]
+            # None of the cvtColor calls should use COLOR_RGB2BGR
+            assert args[1] != mock_cv2.COLOR_RGB2BGR
+
+    @patch(f"{MODULE}.cv2")
+    def test_preprocessing_error_passthrough(self, mock_cv2: MagicMock) -> None:
+        """7.2.1: PreprocessingError raised by a stage passes through without double-wrapping."""
+        mock_cv2.error = type("error", (Exception,), {})
+        # Make cvtColor raise PreprocessingError directly
+        mock_cv2.cvtColor.side_effect = PreprocessingError("Stage failed deliberately")
+
+        preprocessor = ImagePreprocessor()
+
+        with pytest.raises(PreprocessingError, match="Stage failed deliberately"):
+            preprocessor.run(_color_image(), dpi=150)

--- a/tests/unit/processing/test_settings.py
+++ b/tests/unit/processing/test_settings.py
@@ -1,0 +1,93 @@
+"""Tests for ProcessingSettings Pydantic configuration."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from data_collector.settings.processing import ProcessingSettings
+
+
+class TestProcessingSettingsDefaults:
+    """Tests for default field values."""
+
+    def test_default_values(self) -> None:
+        settings = ProcessingSettings()
+        assert settings.text_threshold == 0.9
+        assert settings.min_text_length == 50
+        assert settings.tesseract_language == "eng"
+        assert settings.tesseract_cmd == ""
+        assert settings.min_dpi == 300
+        assert settings.preprocessing_enabled is True
+        assert settings.clahe_clip_limit == 2.0
+        assert settings.clahe_tile_size == 8
+
+
+class TestProcessingSettingsEnvLoading:
+    """Tests for environment variable loading."""
+
+    def test_env_var_loading(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DC_PROCESSING_TEXT_THRESHOLD", "0.8")
+        settings = ProcessingSettings()
+        assert settings.text_threshold == 0.8
+
+    def test_env_prefix(self) -> None:
+        assert ProcessingSettings.model_config.get("env_prefix") == "DC_PROCESSING_"
+
+
+class TestProcessingSettingsDirectConstruction:
+    """Tests for direct keyword construction."""
+
+    def test_direct_construction(self) -> None:
+        settings = ProcessingSettings(text_threshold=0.8, tesseract_language="eng+hrv", min_dpi=200)
+        assert settings.text_threshold == 0.8
+        assert settings.tesseract_language == "eng+hrv"
+        assert settings.min_dpi == 200
+
+
+class TestTextThresholdValidation:
+    """Tests for text_threshold field boundaries."""
+
+    def test_text_threshold_too_low(self) -> None:
+        with pytest.raises(ValidationError):
+            ProcessingSettings(text_threshold=-0.1)
+
+    def test_text_threshold_too_high(self) -> None:
+        with pytest.raises(ValidationError):
+            ProcessingSettings(text_threshold=1.5)
+
+    def test_text_threshold_boundary_zero(self) -> None:
+        settings = ProcessingSettings(text_threshold=0.0)
+        assert settings.text_threshold == 0.0
+
+    def test_text_threshold_boundary_one(self) -> None:
+        settings = ProcessingSettings(text_threshold=1.0)
+        assert settings.text_threshold == 1.0
+
+
+class TestMinTextLengthValidation:
+    """Tests for min_text_length field validation."""
+
+    def test_min_text_length_too_low(self) -> None:
+        with pytest.raises(ValidationError):
+            ProcessingSettings(min_text_length=0)
+
+
+class TestMinDpiValidation:
+    """Tests for min_dpi field validation."""
+
+    def test_min_dpi_too_low(self) -> None:
+        with pytest.raises(ValidationError):
+            ProcessingSettings(min_dpi=50)
+
+
+class TestClaheValidation:
+    """Tests for CLAHE-related field validation."""
+
+    def test_clahe_clip_limit_zero(self) -> None:
+        with pytest.raises(ValidationError):
+            ProcessingSettings(clahe_clip_limit=0)
+
+    def test_clahe_tile_size_too_small(self) -> None:
+        with pytest.raises(ValidationError):
+            ProcessingSettings(clahe_tile_size=1)

--- a/tests/unit/processing/test_training.py
+++ b/tests/unit/processing/test_training.py
@@ -1,0 +1,774 @@
+"""Tests for OCR training dataset management, export, and evaluation utilities."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from data_collector.processing.models import OCRResult, TrainingError
+from data_collector.processing.training import (
+    AccuracyResult,
+    TrainingDataset,
+    TrainingDatasetSplit,
+    TrainingSample,
+    build_character_dictionary,
+    evaluate_ocr_accuracy,
+    generate_paddleocr_config,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _create_dummy_image(path: Path) -> None:
+    """Write a minimal valid PNG file (1x1 white pixel) to the given path."""
+    # Minimal PNG: 8-byte signature + IHDR + IDAT + IEND
+    # Using raw bytes avoids a PIL dependency in test helpers.
+    png_bytes = (
+        b"\x89PNG\r\n\x1a\n"  # PNG signature
+        b"\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+        b"\x08\x02\x00\x00\x00\x90wS\xde"
+        b"\x00\x00\x00\x0cIDATx\x9cc\xf8\x0f\x00\x00\x01\x01\x00\x05\x18\xd8N"
+        b"\x00\x00\x00\x00IEND\xaeB`\x82"
+    )
+    path.write_bytes(png_bytes)
+
+
+def _make_samples(count: int) -> list[TrainingSample]:
+    """Build a list of TrainingSample instances with sequential paths and labels."""
+    return [
+        TrainingSample(image_path=Path(f"/images/img_{index:04d}.png"), ground_truth=f"text_{index}")
+        for index in range(count)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# TrainingSample
+# ---------------------------------------------------------------------------
+
+
+class TestTrainingSample:
+    """Tests for the TrainingSample frozen dataclass."""
+
+    def test_construction(self) -> None:
+        sample = TrainingSample(image_path=Path("/data/image.png"), ground_truth="hello world")
+        assert sample.image_path == Path("/data/image.png")
+        assert sample.ground_truth == "hello world"
+
+    def test_frozen(self) -> None:
+        sample = TrainingSample(image_path=Path("/data/image.png"), ground_truth="hello")
+        with pytest.raises(FrozenInstanceError):
+            sample.image_path = Path("/other.png")  # type: ignore[misc]
+        with pytest.raises(FrozenInstanceError):
+            sample.ground_truth = "changed"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# AccuracyResult
+# ---------------------------------------------------------------------------
+
+
+class TestAccuracyResult:
+    """Tests for the AccuracyResult frozen dataclass."""
+
+    def test_construction(self) -> None:
+        result = AccuracyResult(
+            character_error_rate=0.05,
+            word_error_rate=0.10,
+            total_samples=100,
+            correct_samples=90,
+            exact_match_rate=0.90,
+            skipped_samples=3,
+        )
+        assert result.character_error_rate == pytest.approx(0.05)
+        assert result.word_error_rate == pytest.approx(0.10)
+        assert result.total_samples == 100
+        assert result.correct_samples == 90
+        assert result.exact_match_rate == pytest.approx(0.90)
+        assert result.skipped_samples == 3
+
+    def test_frozen(self) -> None:
+        result = AccuracyResult(
+            character_error_rate=0.0,
+            word_error_rate=0.0,
+            total_samples=1,
+            correct_samples=1,
+            exact_match_rate=1.0,
+            skipped_samples=0,
+        )
+        with pytest.raises(FrozenInstanceError):
+            result.character_error_rate = 0.5  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# TrainingDataset core
+# ---------------------------------------------------------------------------
+
+
+class TestTrainingDataset:
+    """Tests for TrainingDataset construction and property access."""
+
+    def test_construction(self) -> None:
+        samples = _make_samples(5)
+        dataset = TrainingDataset(samples)
+        assert dataset.sample_count == 5
+
+    def test_samples_returns_copy(self) -> None:
+        samples = _make_samples(3)
+        dataset = TrainingDataset(samples)
+
+        returned = dataset.samples
+        returned.pop()
+
+        assert dataset.sample_count == 3, "Modifying the returned list must not affect the dataset"
+
+
+# ---------------------------------------------------------------------------
+# TrainingDataset.from_directory
+# ---------------------------------------------------------------------------
+
+
+class TestFromDirectory:
+    """Tests for loading PaddleOCR-format annotation files."""
+
+    def test_load_paddleocr_format(self, tmp_path: Path) -> None:
+        image_directory = tmp_path / "images"
+        image_directory.mkdir()
+
+        _create_dummy_image(image_directory / "img_001.png")
+        _create_dummy_image(image_directory / "img_002.png")
+
+        annotation_file = tmp_path / "labels.txt"
+        annotation_file.write_text("img_001.png\thello world\nimg_002.png\tfoo bar\n", encoding="utf-8")
+
+        dataset = TrainingDataset.from_directory(image_directory, annotation_file)
+
+        assert dataset.sample_count == 2
+        assert dataset.samples[0].image_path == image_directory / "img_001.png"
+        assert dataset.samples[0].ground_truth == "hello world"
+        assert dataset.samples[1].image_path == image_directory / "img_002.png"
+        assert dataset.samples[1].ground_truth == "foo bar"
+
+    def test_skip_empty_lines(self, tmp_path: Path) -> None:
+        image_directory = tmp_path / "images"
+        image_directory.mkdir()
+
+        _create_dummy_image(image_directory / "img_001.png")
+
+        annotation_file = tmp_path / "labels.txt"
+        annotation_file.write_text("\nimg_001.png\thello\n\n\n", encoding="utf-8")
+
+        dataset = TrainingDataset.from_directory(image_directory, annotation_file)
+        assert dataset.sample_count == 1
+
+    def test_from_directory_malformed_line_skipped(self, tmp_path: Path) -> None:
+        """7.1.13: A line missing the tab separator is skipped; valid lines are still loaded."""
+        image_directory = tmp_path / "images"
+        image_directory.mkdir()
+
+        _create_dummy_image(image_directory / "img_001.png")
+        _create_dummy_image(image_directory / "img_002.png")
+
+        annotation_file = tmp_path / "labels.txt"
+        # Line 1 has no tab, line 2 and 3 are valid
+        annotation_file.write_text(
+            "malformed_line_no_tab\nimg_001.png\thello world\nimg_002.png\tfoo bar\n",
+            encoding="utf-8",
+        )
+
+        dataset = TrainingDataset.from_directory(image_directory, annotation_file)
+
+        assert dataset.sample_count == 2
+        assert dataset.samples[0].ground_truth == "hello world"
+        assert dataset.samples[1].ground_truth == "foo bar"
+
+    def test_from_directory_path_traversal_skipped(self, tmp_path: Path) -> None:
+        """7.3.1: Annotation with path traversal (../../) is skipped with a warning."""
+        image_directory = tmp_path / "images"
+        image_directory.mkdir()
+
+        _create_dummy_image(image_directory / "valid.png")
+
+        annotation_file = tmp_path / "labels.txt"
+        annotation_file.write_text(
+            "../../etc/passwd\tmalicious text\nvalid.png\tgood text\n",
+            encoding="utf-8",
+        )
+
+        dataset = TrainingDataset.from_directory(image_directory, annotation_file)
+
+        # Path traversal line is skipped; only the valid line is loaded
+        assert dataset.sample_count == 1
+        assert dataset.samples[0].ground_truth == "good text"
+
+
+# ---------------------------------------------------------------------------
+# TrainingDataset.from_paired_files
+# ---------------------------------------------------------------------------
+
+
+class TestFromPairedFiles:
+    """Tests for loading Tesseract-style paired image + .gt.txt files."""
+
+    def test_load_tesseract_format(self, tmp_path: Path) -> None:
+        _create_dummy_image(tmp_path / "receipt_001.png")
+        (tmp_path / "receipt_001.gt.txt").write_text("Total: $42.00", encoding="utf-8")
+
+        _create_dummy_image(tmp_path / "receipt_002.png")
+        (tmp_path / "receipt_002.gt.txt").write_text("Tax: $3.50", encoding="utf-8")
+
+        dataset = TrainingDataset.from_paired_files(tmp_path)
+
+        assert dataset.sample_count == 2
+        ground_truths = {sample.ground_truth for sample in dataset.samples}
+        assert ground_truths == {"Total: $42.00", "Tax: $3.50"}
+
+    def test_missing_gt_file_skipped(self, tmp_path: Path) -> None:
+        _create_dummy_image(tmp_path / "image_with_gt.png")
+        (tmp_path / "image_with_gt.gt.txt").write_text("has ground truth", encoding="utf-8")
+
+        _create_dummy_image(tmp_path / "image_without_gt.png")
+        # Intentionally no .gt.txt for this image
+
+        dataset = TrainingDataset.from_paired_files(tmp_path)
+        assert dataset.sample_count == 1
+        assert dataset.samples[0].ground_truth == "has ground truth"
+
+
+# ---------------------------------------------------------------------------
+# TrainingDataset.split
+# ---------------------------------------------------------------------------
+
+
+class TestSplit:
+    """Tests for deterministic dataset splitting."""
+
+    def test_split_ratio(self) -> None:
+        dataset = TrainingDataset(_make_samples(10))
+        split_result = dataset.split(train_ratio=0.9, seed=42)
+
+        assert isinstance(split_result, TrainingDatasetSplit)
+        assert split_result.training_count == 9
+        assert split_result.evaluation_count == 1
+        assert split_result.training_count + split_result.evaluation_count == 10
+
+    def test_deterministic_with_seed(self) -> None:
+        dataset = TrainingDataset(_make_samples(20))
+        first_split = dataset.split(train_ratio=0.8, seed=99)
+        second_split = dataset.split(train_ratio=0.8, seed=99)
+
+        assert first_split.training_samples == second_split.training_samples
+        assert first_split.evaluation_samples == second_split.evaluation_samples
+
+    def test_different_seed_different_split(self) -> None:
+        dataset = TrainingDataset(_make_samples(20))
+        split_seed_one = dataset.split(train_ratio=0.8, seed=1)
+        split_seed_two = dataset.split(train_ratio=0.8, seed=2)
+
+        assert split_seed_one.training_samples != split_seed_two.training_samples
+
+    def test_split_empty_dataset(self) -> None:
+        """7.1.14: Splitting an empty dataset returns empty tuples and zero counts."""
+        dataset = TrainingDataset([])
+        split_result = dataset.split(train_ratio=0.9, seed=42)
+
+        assert split_result.training_samples == ()
+        assert split_result.evaluation_samples == ()
+        assert split_result.training_count == 0
+        assert split_result.evaluation_count == 0
+
+    def test_split_single_sample(self) -> None:
+        """7.1.15: Splitting 1 sample with ratio=0.9 puts nothing in training, 1 in evaluation."""
+        dataset = TrainingDataset(_make_samples(1))
+        split_result = dataset.split(train_ratio=0.9, seed=42)
+
+        # int(1 * 0.9) = 0, so split_index=0: training is empty, evaluation has 1 sample
+        assert split_result.training_count == 0
+        assert split_result.evaluation_count == 1
+        assert len(split_result.evaluation_samples) == 1
+
+    def test_split_invalid_ratio_negative(self) -> None:
+        """7.3.1: Negative train_ratio raises ValueError."""
+        dataset = TrainingDataset(_make_samples(10))
+
+        with pytest.raises(ValueError, match="train_ratio must be between 0.0 and 1.0"):
+            dataset.split(train_ratio=-0.5, seed=42)
+
+    def test_split_invalid_ratio_above_one(self) -> None:
+        """7.3.1: train_ratio > 1.0 raises ValueError."""
+        dataset = TrainingDataset(_make_samples(10))
+
+        with pytest.raises(ValueError, match="train_ratio must be between 0.0 and 1.0"):
+            dataset.split(train_ratio=1.5, seed=42)
+
+
+# ---------------------------------------------------------------------------
+# TrainingDataset.export_paddleocr
+# ---------------------------------------------------------------------------
+
+
+class TestExportPaddleocr:
+    """Tests for PaddleOCR training directory export."""
+
+    def test_creates_directory_structure(self, tmp_path: Path) -> None:
+        image_directory = tmp_path / "source_images"
+        image_directory.mkdir()
+        samples: list[TrainingSample] = []
+        for index in range(4):
+            image_path = image_directory / f"img_{index:04d}.png"
+            _create_dummy_image(image_path)
+            samples.append(TrainingSample(image_path=image_path, ground_truth=f"text {index}"))
+
+        dataset = TrainingDataset(samples)
+        output_directory = tmp_path / "output"
+        dataset.export_paddleocr(output_directory)
+
+        assert (output_directory / "train").is_dir()
+        assert (output_directory / "eval").is_dir()
+        assert (output_directory / "dict.txt").is_file()
+
+    def test_annotation_files_written(self, tmp_path: Path) -> None:
+        image_directory = tmp_path / "source_images"
+        image_directory.mkdir()
+        samples: list[TrainingSample] = []
+        for index in range(4):
+            image_path = image_directory / f"img_{index:04d}.png"
+            _create_dummy_image(image_path)
+            samples.append(TrainingSample(image_path=image_path, ground_truth=f"label_{index}"))
+
+        dataset = TrainingDataset(samples)
+        output_directory = tmp_path / "output"
+        dataset.export_paddleocr(output_directory)
+
+        training_annotation = output_directory / "train" / "rec_gt_train.txt"
+        evaluation_annotation = output_directory / "eval" / "rec_gt_eval.txt"
+
+        assert training_annotation.is_file()
+        assert evaluation_annotation.is_file()
+
+        training_lines = [
+            line for line in training_annotation.read_text(encoding="utf-8").splitlines() if line.strip()
+        ]
+        evaluation_lines = [
+            line for line in evaluation_annotation.read_text(encoding="utf-8").splitlines() if line.strip()
+        ]
+
+        assert len(training_lines) + len(evaluation_lines) == 4
+
+        # Each annotation line must be tab-separated: relative_path<TAB>ground_truth
+        for line in training_lines + evaluation_lines:
+            parts = line.split("\t")
+            assert len(parts) == 2, f"Expected tab-separated annotation, got: {line}"
+
+    def test_export_paddleocr_empty_dataset(self, tmp_path: Path) -> None:
+        """7.1.16: Exporting an empty dataset creates directories and empty annotation files."""
+        dataset = TrainingDataset([])
+        output_directory = tmp_path / "output"
+        dataset.export_paddleocr(output_directory)
+
+        assert (output_directory / "train").is_dir()
+        assert (output_directory / "eval").is_dir()
+        assert (output_directory / "dict.txt").is_file()
+        assert (output_directory / "train" / "rec_gt_train.txt").is_file()
+        assert (output_directory / "eval" / "rec_gt_eval.txt").is_file()
+
+    def test_export_paddleocr_idempotent(self, tmp_path: Path) -> None:
+        """7.3.1: Running export_paddleocr twice produces no errors on the second run."""
+        image_directory = tmp_path / "source_images"
+        image_directory.mkdir()
+        samples: list[TrainingSample] = []
+        for index in range(3):
+            image_path = image_directory / f"img_{index:04d}.png"
+            _create_dummy_image(image_path)
+            samples.append(TrainingSample(image_path=image_path, ground_truth=f"text {index}"))
+
+        dataset = TrainingDataset(samples)
+        output_directory = tmp_path / "output"
+
+        # First export
+        dataset.export_paddleocr(output_directory)
+        # Second export -- should not raise
+        dataset.export_paddleocr(output_directory)
+
+        assert (output_directory / "train").is_dir()
+        assert (output_directory / "dict.txt").is_file()
+
+
+# ---------------------------------------------------------------------------
+# TrainingDataset.export_tesseract
+# ---------------------------------------------------------------------------
+
+
+class TestExportTesseract:
+    """Tests for Tesseract tesstrain directory export."""
+
+    def test_creates_ground_truth_directory(self, tmp_path: Path) -> None:
+        image_directory = tmp_path / "source_images"
+        image_directory.mkdir()
+        samples: list[TrainingSample] = []
+        for index in range(3):
+            image_path = image_directory / f"img_{index:04d}.png"
+            _create_dummy_image(image_path)
+            samples.append(TrainingSample(image_path=image_path, ground_truth=f"word_{index}"))
+
+        dataset = TrainingDataset(samples)
+        output_directory = tmp_path / "output"
+
+        with patch("data_collector.processing.training.Image.open") as mock_open:
+            mock_image = MagicMock()
+            mock_open.return_value = mock_image
+            dataset.export_tesseract(output_directory, model_name="test_model")
+
+        ground_truth_directory = output_directory / "data" / "test_model-ground-truth"
+        assert ground_truth_directory.is_dir()
+
+    def test_gt_txt_files_written(self, tmp_path: Path) -> None:
+        image_directory = tmp_path / "source_images"
+        image_directory.mkdir()
+        samples: list[TrainingSample] = []
+        for index in range(3):
+            image_path = image_directory / f"img_{index:04d}.png"
+            _create_dummy_image(image_path)
+            samples.append(TrainingSample(image_path=image_path, ground_truth=f"word_{index}"))
+
+        dataset = TrainingDataset(samples)
+        output_directory = tmp_path / "output"
+
+        with patch("data_collector.processing.training.Image.open") as mock_open:
+            mock_image = MagicMock()
+            mock_open.return_value = mock_image
+            dataset.export_tesseract(output_directory, model_name="my_model")
+
+        ground_truth_directory = output_directory / "data" / "my_model-ground-truth"
+
+        for index in range(3):
+            ground_truth_file = ground_truth_directory / f"sample_{index:06d}.gt.txt"
+            assert ground_truth_file.is_file(), f"Expected {ground_truth_file} to exist"
+            content = ground_truth_file.read_text(encoding="utf-8")
+            assert content == f"word_{index}"
+
+    def test_export_tesseract_tiff_copy(self, tmp_path: Path) -> None:
+        """7.1.17: When source is .tif, shutil.copy2 is used instead of Image.open+save."""
+        image_directory = tmp_path / "source_images"
+        image_directory.mkdir()
+
+        tif_path = image_directory / "receipt.tif"
+        _create_dummy_image(tif_path)  # Content doesn't matter; copy2 just copies bytes
+
+        samples = [TrainingSample(image_path=tif_path, ground_truth="Total: $42.00")]
+        dataset = TrainingDataset(samples)
+        output_directory = tmp_path / "output"
+
+        with (
+            patch("data_collector.processing.training.shutil.copy2") as mock_copy2,
+            patch("data_collector.processing.training.Image.open") as mock_image_open,
+        ):
+            dataset.export_tesseract(output_directory, model_name="tif_model")
+
+            mock_copy2.assert_called_once()
+            mock_image_open.assert_not_called()
+
+    def test_export_tesseract_saves_as_tiff(self, tmp_path: Path) -> None:
+        """7.4.3: For non-TIFF source images, Image.save is called with format='TIFF'."""
+        image_directory = tmp_path / "source_images"
+        image_directory.mkdir()
+
+        png_path = image_directory / "receipt.png"
+        _create_dummy_image(png_path)
+
+        samples = [TrainingSample(image_path=png_path, ground_truth="Total: $42.00")]
+        dataset = TrainingDataset(samples)
+        output_directory = tmp_path / "output"
+
+        with patch("data_collector.processing.training.Image.open") as mock_open:
+            mock_image = MagicMock()
+            # Source uses 'with Image.open(...) as source_image:', so mock context manager
+            mock_open.return_value.__enter__ = MagicMock(return_value=mock_image)
+            mock_open.return_value.__exit__ = MagicMock(return_value=False)
+            dataset.export_tesseract(output_directory, model_name="png_model")
+
+            mock_image.save.assert_called_once()
+            # Source code calls source_image.save(target_image_path, format="TIFF")
+            _save_args, save_kwargs = mock_image.save.call_args
+            assert save_kwargs.get("format") == "TIFF"
+
+
+# ---------------------------------------------------------------------------
+# build_character_dictionary
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCharacterDictionary:
+    """Tests for building sorted character dictionaries from training samples."""
+
+    def test_extracts_unique_characters(self) -> None:
+        samples = [
+            TrainingSample(image_path=Path("/img/a.png"), ground_truth="abc"),
+            TrainingSample(image_path=Path("/img/b.png"), ground_truth="bcd"),
+        ]
+        dictionary = build_character_dictionary(samples, include_special=False)
+        assert dictionary == ["a", "b", "c", "d"]
+
+    def test_includes_special_characters(self) -> None:
+        samples = [
+            TrainingSample(image_path=Path("/img/a.png"), ground_truth="hello world"),
+        ]
+        dictionary = build_character_dictionary(samples, include_special=True)
+        # "hello world" contains a space; include_special=True guarantees space is present
+        assert " " in dictionary
+
+    def test_accepts_training_dataset(self) -> None:
+        samples = [
+            TrainingSample(image_path=Path("/img/a.png"), ground_truth="xyz"),
+        ]
+        dataset = TrainingDataset(samples)
+        dictionary = build_character_dictionary(dataset, include_special=False)
+        assert dictionary == ["x", "y", "z"]
+
+    def test_build_dictionary_empty_samples(self) -> None:
+        """7.1.18: Empty sample list with include_special=False returns empty list."""
+        dictionary = build_character_dictionary([], include_special=False)
+        assert dictionary == []
+
+    def test_build_dictionary_empty_samples_with_special(self) -> None:
+        """7.1.18: Empty sample list with include_special=True returns only special characters."""
+        dictionary = build_character_dictionary([], include_special=True)
+        assert len(dictionary) > 0
+        assert " " in dictionary
+
+
+# ---------------------------------------------------------------------------
+# generate_paddleocr_config
+# ---------------------------------------------------------------------------
+
+
+class TestGeneratePaddleOcrConfig:
+    """Tests for PaddleOCR YAML config file generation."""
+
+    def test_generates_yaml_file(self, tmp_path: Path) -> None:
+        dictionary_path = tmp_path / "dict.txt"
+        dictionary_path.write_text("a\nb\nc\n", encoding="utf-8")
+
+        training_data_path = tmp_path / "train"
+        training_data_path.mkdir()
+        evaluation_data_path = tmp_path / "eval"
+        evaluation_data_path.mkdir()
+
+        config_path = generate_paddleocr_config(
+            model_name="my_ocr_model",
+            dictionary_path=dictionary_path,
+            training_data_path=training_data_path,
+            evaluation_data_path=evaluation_data_path,
+            learning_rate=0.0005,
+            epochs=50,
+            output_directory=tmp_path / "config_output",
+        )
+
+        assert config_path.is_file()
+        config_content = config_path.read_text(encoding="utf-8")
+        assert "my_ocr_model" in config_content
+        assert "0.0005" in config_content
+        assert "epoch_num: 50" in config_content
+
+    def test_config_contains_paths(self, tmp_path: Path) -> None:
+        dictionary_path = tmp_path / "dict.txt"
+        dictionary_path.write_text("a\n", encoding="utf-8")
+
+        training_data_path = tmp_path / "train"
+        training_data_path.mkdir()
+        evaluation_data_path = tmp_path / "eval"
+        evaluation_data_path.mkdir()
+
+        config_path = generate_paddleocr_config(
+            model_name="path_test",
+            dictionary_path=dictionary_path,
+            training_data_path=training_data_path,
+            evaluation_data_path=evaluation_data_path,
+            output_directory=tmp_path / "config_output",
+        )
+
+        config_content = config_path.read_text(encoding="utf-8")
+        assert str(dictionary_path) in config_content
+        assert str(training_data_path) in config_content
+        assert str(evaluation_data_path) in config_content
+
+    def test_generate_config_default_output_directory(self, tmp_path: Path) -> None:
+        """7.1.21: When output_directory=None, config is created in parent of training_data_path."""
+        dictionary_path = tmp_path / "dict.txt"
+        dictionary_path.write_text("a\nb\n", encoding="utf-8")
+
+        training_data_path = tmp_path / "data" / "train"
+        training_data_path.mkdir(parents=True)
+        evaluation_data_path = tmp_path / "data" / "eval"
+        evaluation_data_path.mkdir(parents=True)
+
+        config_path = generate_paddleocr_config(
+            model_name="default_dir_test",
+            dictionary_path=dictionary_path,
+            training_data_path=training_data_path,
+            evaluation_data_path=evaluation_data_path,
+            output_directory=None,
+        )
+
+        # Default output_directory is training_data_path.parent (tmp_path / "data")
+        assert config_path.parent == training_data_path.parent
+        assert config_path.is_file()
+        assert config_path.name == "default_dir_test_config.yml"
+
+    def test_generate_config_invalid_epochs(self, tmp_path: Path) -> None:
+        """7.3.1: Negative epochs raises TrainingError."""
+        dictionary_path = tmp_path / "dict.txt"
+        dictionary_path.write_text("a\n", encoding="utf-8")
+
+        training_data_path = tmp_path / "train"
+        training_data_path.mkdir()
+        evaluation_data_path = tmp_path / "eval"
+        evaluation_data_path.mkdir()
+
+        with pytest.raises(TrainingError, match="epochs must be >= 1"):
+            generate_paddleocr_config(
+                model_name="neg_epochs",
+                dictionary_path=dictionary_path,
+                training_data_path=training_data_path,
+                evaluation_data_path=evaluation_data_path,
+                epochs=-10,
+                output_directory=tmp_path / "config_output",
+            )
+
+    def test_generate_config_invalid_batch_size(self, tmp_path: Path) -> None:
+        """7.3.1: Zero batch_size raises TrainingError."""
+        dictionary_path = tmp_path / "dict.txt"
+        dictionary_path.write_text("a\n", encoding="utf-8")
+
+        training_data_path = tmp_path / "train"
+        training_data_path.mkdir()
+        evaluation_data_path = tmp_path / "eval"
+        evaluation_data_path.mkdir()
+
+        with pytest.raises(TrainingError, match="batch_size must be >= 1"):
+            generate_paddleocr_config(
+                model_name="zero_batch",
+                dictionary_path=dictionary_path,
+                training_data_path=training_data_path,
+                evaluation_data_path=evaluation_data_path,
+                batch_size=0,
+                output_directory=tmp_path / "config_output",
+            )
+
+
+# ---------------------------------------------------------------------------
+# evaluate_ocr_accuracy
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateOcrAccuracy:
+    """Tests for OCR accuracy evaluation with mocked engine and image loading."""
+
+    def test_perfect_accuracy(self) -> None:
+        samples = [
+            TrainingSample(image_path=Path("/img/a.png"), ground_truth="hello"),
+            TrainingSample(image_path=Path("/img/b.png"), ground_truth="world"),
+        ]
+
+        mock_engine = MagicMock()
+        mock_engine.extract_text.side_effect = [
+            OCRResult(text="hello", engine_name="mock", preprocessed=False, confidence=1.0),
+            OCRResult(text="world", engine_name="mock", preprocessed=False, confidence=1.0),
+        ]
+
+        with patch("data_collector.processing.training.Image.open") as mock_open:
+            mock_open.return_value = MagicMock()
+            result = evaluate_ocr_accuracy(mock_engine, samples)
+
+        assert result.character_error_rate == pytest.approx(0.0)
+        assert result.word_error_rate == pytest.approx(0.0)
+        assert result.exact_match_rate == pytest.approx(1.0)
+        assert result.total_samples == 2
+        assert result.correct_samples == 2
+
+    def test_partial_accuracy(self) -> None:
+        samples = [
+            TrainingSample(image_path=Path("/img/a.png"), ground_truth="hello"),
+        ]
+
+        # Return "hallo" instead of "hello" -- one character difference
+        mock_engine = MagicMock()
+        mock_engine.extract_text.return_value = OCRResult(
+            text="hallo", engine_name="mock", preprocessed=False, confidence=0.8,
+        )
+
+        with patch("data_collector.processing.training.Image.open") as mock_open:
+            mock_open.return_value = MagicMock()
+            result = evaluate_ocr_accuracy(mock_engine, samples)
+
+        assert result.character_error_rate > 0.0
+        assert result.exact_match_rate == pytest.approx(0.0)
+        assert result.total_samples == 1
+        assert result.correct_samples == 0
+
+    def test_empty_result(self) -> None:
+        samples = [
+            TrainingSample(image_path=Path("/img/a.png"), ground_truth="expected text"),
+        ]
+
+        mock_engine = MagicMock()
+        mock_engine.extract_text.return_value = OCRResult(
+            text="", engine_name="mock", preprocessed=False, confidence=0.0,
+        )
+
+        with patch("data_collector.processing.training.Image.open") as mock_open:
+            mock_open.return_value = MagicMock()
+            result = evaluate_ocr_accuracy(mock_engine, samples)
+
+        # Empty prediction against non-empty ground truth => high CER
+        assert result.character_error_rate > 0.5
+        assert result.exact_match_rate == pytest.approx(0.0)
+        assert result.correct_samples == 0
+
+    def test_evaluate_empty_samples(self) -> None:
+        """7.1.19: Evaluate with empty sample list returns CER=0, WER=0, total=0."""
+        mock_engine = MagicMock()
+
+        result = evaluate_ocr_accuracy(mock_engine, [])
+
+        assert result.character_error_rate == pytest.approx(0.0)
+        assert result.word_error_rate == pytest.approx(0.0)
+        assert result.total_samples == 0
+        assert result.correct_samples == 0
+        assert result.exact_match_rate == pytest.approx(0.0)
+        mock_engine.extract_text.assert_not_called()
+
+    def test_evaluate_with_preprocessor(self) -> None:
+        """7.1.20: When additional_preprocessor is passed, it is called on each image before OCR."""
+        samples = [
+            TrainingSample(image_path=Path("/img/a.png"), ground_truth="hello"),
+            TrainingSample(image_path=Path("/img/b.png"), ground_truth="world"),
+        ]
+
+        mock_engine = MagicMock()
+        mock_engine.extract_text.side_effect = [
+            OCRResult(text="hello", engine_name="mock", preprocessed=True, confidence=1.0),
+            OCRResult(text="world", engine_name="mock", preprocessed=True, confidence=1.0),
+        ]
+
+        mock_preprocessor = MagicMock()
+        mock_preprocessed_image = MagicMock()
+        mock_preprocessor.run.return_value = mock_preprocessed_image
+
+        with patch("data_collector.processing.training.Image.open") as mock_open:
+            mock_image = MagicMock()
+            mock_open.return_value.__enter__ = MagicMock(return_value=mock_image)
+            mock_open.return_value.__exit__ = MagicMock(return_value=False)
+            result = evaluate_ocr_accuracy(
+                mock_engine, samples, additional_preprocessor=mock_preprocessor
+            )
+
+        assert mock_preprocessor.run.call_count == 2
+        # The preprocessed image should be passed to the engine
+        for engine_call in mock_engine.extract_text.call_args_list:
+            assert engine_call[0][0] is mock_preprocessed_image
+        assert result.total_samples == 2
+        assert result.correct_samples == 2


### PR DESCRIPTION
## Work Package
WP-14: PDF/OCR Processing

## Summary
- Add PDF text/table extraction via pdfplumber with whole-document classification (text vs image)
- Add OCR adapter pattern with PaddleOCR as primary engine (F1=0.938) and Tesseract as fallback
- Add 8-stage image preprocessing pipeline (grayscale, upscale, denoise, CLAHE contrast, deskew, binarize, morphology, border)
- Add training utilities: dataset management, PaddleOCR/Tesseract export, character dictionary builder, CER/WER accuracy evaluation
- Add ProcessingSettings with DC_PROCESSING_ env prefix and GPU extras group in pyproject.toml
- Add PdfDataType and DocumentType (reserved) enums

## Changes
- `data_collector/enums/processing.py` -- PdfDataType (TEXT/IMAGE) and DocumentType (reserved) StrEnums
- `data_collector/enums/__init__.py` -- export PdfDataType and DocumentType
- `data_collector/settings/processing.py` -- ProcessingSettings with 8 configurable fields and validators
- `data_collector/processing/models.py` -- frozen dataclasses (PDFClassification, PDFText, PDFTable, OCRResult), exception hierarchy (ProcessingError, PDFExtractionError, OCRError, PreprocessingError, TrainingError)
- `data_collector/processing/preprocessing.py` -- ImagePreprocessor with 8-stage OpenCV pipeline
- `data_collector/processing/pdf.py` -- classify_pdf(), extract_text_pdfplumber(), extract_tables_pdfplumber()
- `data_collector/processing/ocr.py` -- OCREngine ABC, PaddleOCREngine (primary), TesseractEngine (fallback), extract_text_ocr()
- `data_collector/processing/training.py` -- TrainingDataset, build_character_dictionary(), generate_paddleocr_config(), evaluate_ocr_accuracy()
- `data_collector/processing/__init__.py` -- package exports
- `requirements.txt` -- added pdfplumber, pytesseract, Pillow, opencv-python-headless, paddleocr, paddlepaddle
- `pyproject.toml` -- added [gpu] extras group (paddlepaddle-gpu)
- `docs/14. pdf-ocr.md` -- status IMPLEMENTED, full documentation rewrite
- `tests/unit/processing/` -- 8 test files, 150 tests covering all modules

## Testing
- `ruff check` -- passed (0 errors)
- `pytest tests/unit tests/quality` -- 1532 passed
- `python data_collector/utilities/validate_docs.py` -- 43 files validated
- REVIEW.md 7-phase self-review protocol -- all phases passed, all findings fixed

## Related
- [docs/14. pdf-ocr.md](docs/14.%20pdf-ocr.md) -- feature specification
- [docs/50. roadmap.md](docs/50.%20roadmap.md) -- WP-14 scope definition
- [docs/20. storage.md](docs/20.%20storage.md) -- WP-13 Storage (dependency)

Generated with [Claude Code](https://claude.com/claude-code)