### PR TITLE
fix: enforce logging context integrity and DB data quality

### DIFF
--- a/data_collector/examples/fun_watch/01_basic_decorator.py
+++ b/data_collector/examples/fun_watch/01_basic_decorator.py
@@ -39,6 +39,7 @@ from data_collector.tables.log import FunctionLog, Logs
 from data_collector.tables.runtime import Runtime
 from data_collector.utilities.database.main import Database
 from data_collector.utilities.fun_watch import FunWatchMixin, FunWatchRegistry, fun_watch
+from data_collector.utilities.functions.math import get_totalh, get_totalm, get_totals
 from data_collector.utilities.functions.runtime import AppInfo, get_app_info
 from data_collector.utilities.log.main import LoggingService
 
@@ -58,10 +59,16 @@ class DemoApp(FunWatchMixin):
 
     @fun_watch
     def process_records(self, records: list[str]) -> int:
-        """Process a batch of records, marking each as solved."""
+        """Process a batch of records, marking each as solved.
+
+        Includes a 1.5-second sleep to demonstrate that FunctionLog duration
+        columns (totals, totalm, totalh) are populated correctly for
+        functions that take measurable time.
+        """
         for _record in records:
             self.logger.debug(f"processing record: {_record}")
             self._fun_watch.mark_solved()
+        time.sleep(1.5)
         return len(records)
 
     @fun_watch
@@ -120,6 +127,22 @@ def _seed_parent_rows(db: Database, app_info: AppInfo, runtime_id: str) -> None:
         session.commit()
 
 
+def _complete_runtime(db: Database, runtime_id: str, start_time: datetime, exception_count: int = 0) -> None:
+    """Finalize Runtime row with end_time, duration, and exception count."""
+    end_time = datetime.now(UTC)
+    with db.create_session() as session:
+        record = db.query(
+            select(Runtime).where(Runtime.runtime == runtime_id), session,
+        ).scalar_one_or_none()
+        if record is not None:
+            record.end_time = end_time  # type: ignore[assignment]
+            record.totals = get_totals(start_time, end_time)  # type: ignore[assignment]
+            record.totalm = get_totalm(start_time, end_time)  # type: ignore[assignment]
+            record.totalh = get_totalh(start_time, end_time)  # type: ignore[assignment]
+            record.except_cnt = exception_count  # type: ignore[assignment]
+            session.commit()
+
+
 def _print_results(db: Database, app_id: str) -> None:
     """Query and print all rows inserted by this example."""
     with db.create_session() as session:
@@ -170,6 +193,7 @@ def main() -> None:
     FunWatchRegistry.instance().set_system_db(deploy.database)
 
     db = deploy.database
+    runtime_start = datetime.now(UTC)
     _seed_parent_rows(db, app_info, runtime_id)
 
     log_settings = LogSettings(log_level=10, log_error_file="error.log")
@@ -208,7 +232,8 @@ def main() -> None:
             except RuntimeError as exc:
                 logger.warning("Exception re-raised", error=str(exc))
 
-            # Let QueueListener flush pending log records to DB
+            # Finalize Runtime row and let QueueListener flush pending log records to DB
+            _complete_runtime(db, runtime_id, runtime_start, exception_count=1)
             time.sleep(0.5)
             _print_results(db, app_id)
 

--- a/data_collector/examples/fun_watch/02_database_rows.py
+++ b/data_collector/examples/fun_watch/02_database_rows.py
@@ -40,6 +40,7 @@ from data_collector.tables.log import FunctionLog, Logs
 from data_collector.tables.runtime import Runtime
 from data_collector.utilities.database.main import Database
 from data_collector.utilities.fun_watch import FunWatchMixin, FunWatchRegistry, fun_watch
+from data_collector.utilities.functions.math import get_totalh, get_totalm, get_totals
 from data_collector.utilities.functions.runtime import AppInfo, get_app_id, get_app_info
 from data_collector.utilities.log.main import LoggingService
 
@@ -119,6 +120,22 @@ def _seed_parent_rows(db: Database, app_info: AppInfo, apps: list[tuple[str, str
         session.commit()
 
 
+def _complete_runtime(db: Database, runtime_id: str, start_time: datetime, exception_count: int = 0) -> None:
+    """Finalize Runtime row with end_time, duration, and exception count."""
+    end_time = datetime.now(UTC)
+    with db.create_session() as session:
+        record = db.query(
+            select(Runtime).where(Runtime.runtime == runtime_id), session,
+        ).scalar_one_or_none()
+        if record is not None:
+            record.end_time = end_time  # type: ignore[assignment]
+            record.totals = get_totals(start_time, end_time)  # type: ignore[assignment]
+            record.totalm = get_totalm(start_time, end_time)  # type: ignore[assignment]
+            record.totalh = get_totalh(start_time, end_time)  # type: ignore[assignment]
+            record.except_cnt = exception_count  # type: ignore[assignment]
+            session.commit()
+
+
 def _print_results(db: Database, app_ids: list[str]) -> None:
     """Query and print all rows inserted by this example."""
     with db.create_session() as session:
@@ -173,6 +190,7 @@ def main() -> None:
     FunWatchRegistry.instance().set_system_db(deploy.database)
 
     db = deploy.database
+    runtime_start = datetime.now(UTC)
     _seed_parent_rows(db, app_info, [
         (app_id_main, app_info["app_name"], runtime_main),
         (app_id_child, app_info["app_name"] + "_child", runtime_child),
@@ -216,7 +234,9 @@ def main() -> None:
             )
             child2.fetch_pages(["https://y.com"])
 
-            # Let QueueListener flush pending log records to DB
+            # Finalize Runtime rows and let QueueListener flush
+            _complete_runtime(db, runtime_main, runtime_start)
+            _complete_runtime(db, runtime_child, runtime_start)
             time.sleep(0.5)
             _print_results(db, app_ids)
 

--- a/data_collector/examples/fun_watch/03_multithreaded.py
+++ b/data_collector/examples/fun_watch/03_multithreaded.py
@@ -42,6 +42,7 @@ from data_collector.tables.log import FunctionLog, FunctionLogError, Logs
 from data_collector.tables.runtime import Runtime
 from data_collector.utilities.database.main import Database
 from data_collector.utilities.fun_watch import FunWatchMixin, FunWatchRegistry, fun_watch
+from data_collector.utilities.functions.math import get_totalh, get_totalm, get_totals
 from data_collector.utilities.functions.runtime import AppInfo, get_app_info
 from data_collector.utilities.log.main import LoggingService
 
@@ -124,6 +125,22 @@ def _seed_parent_rows(db: Database, app_info: AppInfo, runtime_id: str) -> None:
             start_time=datetime.now(UTC),
         ))
         session.commit()
+
+
+def _complete_runtime(db: Database, runtime_id: str, start_time: datetime, exception_count: int = 0) -> None:
+    """Finalize Runtime row with end_time, duration, and exception count."""
+    end_time = datetime.now(UTC)
+    with db.create_session() as session:
+        record = db.query(
+            select(Runtime).where(Runtime.runtime == runtime_id), session,
+        ).scalar_one_or_none()
+        if record is not None:
+            record.end_time = end_time  # type: ignore[assignment]
+            record.totals = get_totals(start_time, end_time)  # type: ignore[assignment]
+            record.totalm = get_totalm(start_time, end_time)  # type: ignore[assignment]
+            record.totalh = get_totalh(start_time, end_time)  # type: ignore[assignment]
+            record.except_cnt = exception_count  # type: ignore[assignment]
+            session.commit()
 
 
 def _print_results(db: Database, app_id: str) -> None:
@@ -216,6 +233,7 @@ def main() -> None:
     FunWatchRegistry.instance().set_system_db(deploy.database)
 
     db = deploy.database
+    runtime_start = datetime.now(UTC)
     _seed_parent_rows(db, app_info, runtime_id)
 
     log_settings = LogSettings(log_level=10, log_error_file="error.log")
@@ -303,7 +321,8 @@ def main() -> None:
                             error=str(exc),
                         )
 
-            # Let QueueListener flush pending log records to DB
+            # Finalize Runtime row and let QueueListener flush
+            _complete_runtime(db, runtime_id, runtime_start, exception_count=2)
             time.sleep(0.5)
             _print_results(db, app_id)
 

--- a/data_collector/examples/scraping/abort_blocker/main.py
+++ b/data_collector/examples/scraping/abort_blocker/main.py
@@ -98,7 +98,11 @@ class AbortBlocker(ThreadedScraper):
         response = request.get(item)
         if response is None:
             print(f"  FAILED [{instance_id}]: {item}")
-            self.increment_failed(error_category=request.get_error_category())
+            self.increment_failed(
+                error_category=request.get_error_category(),
+                error_type="ConnectionError",
+                error_message=f"{item}: connection failed",
+            )
             return
 
         books = self.parser.parse_catalogue(response.content)
@@ -112,7 +116,11 @@ class AbortBlocker(ThreadedScraper):
 
         if should_simulate:
             print(f"  SIMULATING DATABASE ERROR [{instance_id}]: {item}")
-            self.increment_failed(error_category=ErrorCategory.DATABASE)
+            self.increment_failed(
+                error_category=ErrorCategory.DATABASE,
+                error_type="DatabaseError",
+                error_message=f"{item}: simulated database write failure",
+            )
             return
 
         if books:

--- a/data_collector/examples/scraping/abort_http/main.py
+++ b/data_collector/examples/scraping/abort_http/main.py
@@ -91,6 +91,7 @@ class AbortHttp(BaseScraper):
     def collect(self) -> None:
         """Fetch each URL, detecting non-2xx as HTTP errors."""
         self._start_collect_timer()
+        self._fun_watch.set_task_size(self.list_size)
         for url in self.work_list:
             if self.should_abort:
                 print("\n  ABORT: should_abort=True, stopping collection loop")
@@ -101,13 +102,21 @@ class AbortHttp(BaseScraper):
             response = self.request.get(url)
             if response is None:
                 print(f"  FAILED (connection): {url}")
-                self.increment_failed(error_category=self.request.get_error_category())
+                self.increment_failed(
+                    error_category=self.request.get_error_category(),
+                    error_type="ConnectionError",
+                    error_message=f"{url}: connection failed",
+                )
                 self.update_progress()
                 continue
 
             if response.status_code < 200 or response.status_code >= 300:
                 print(f"  FAILED (HTTP {response.status_code}): {url}")
-                self.increment_failed(error_category=ErrorCategory.HTTP)
+                self.increment_failed(
+                    error_category=ErrorCategory.HTTP,
+                    error_type=f"HTTP_{response.status_code}",
+                    error_message=f"{url}: HTTP {response.status_code}",
+                )
                 self.update_progress()
                 continue
 

--- a/data_collector/examples/scraping/books/main.py
+++ b/data_collector/examples/scraping/books/main.py
@@ -70,6 +70,7 @@ class Books(BaseScraper):
     def collect(self) -> None:
         """Fetch each catalogue page and parse book listings."""
         self._start_collect_timer()
+        self._fun_watch.set_task_size(self.list_size)
         for url in self.work_list:
             if self.should_abort:
                 break

--- a/data_collector/tables/log.py
+++ b/data_collector/tables/log.py
@@ -37,8 +37,12 @@ class Logs(Base):
     module_name = Column(String(length=256), doc="Module name (.py) from where logging is coming")
     module_path = Column(UnicodeText, doc="Module path from where logging is coming.")
     function_name = Column(String(length=256), doc="Function name from where logging is coming")
-    function_id = Column(String(length=64), index=True,
-                         doc="It is hashed value of app_id, module_name and function_name ")
+    function_id = Column(
+        String(length=64),
+        ForeignKey(AppFunctions.function_hash, ondelete="CASCADE"),
+        index=True,
+        doc="SHA3-256 hash of app_id + function_name, references app_functions.function_hash",
+    )
 
 
     call_chain = Column(UnicodeText, doc="Contains call chain from root caller to actual logging caller")

--- a/data_collector/utilities/fun_watch.py
+++ b/data_collector/utilities/fun_watch.py
@@ -316,7 +316,10 @@ class FunWatchRegistry:
         def wrapped(*args: Any, **kwargs: Any) -> T:
             token = self.bind_context(parent_context)
             structlog.contextvars.bind_contextvars(**parent_structlog_context)
-            structlog.contextvars.bind_contextvars(thread_id=threading.get_ident())
+            parent_chain = parent_structlog_context.get("call_chain", "")
+            worker_name = getattr(func, "__qualname__", None) or getattr(func, "__name__", "worker")
+            extended_chain = f"{parent_chain} -> {worker_name}" if parent_chain else worker_name
+            structlog.contextvars.bind_contextvars(thread_id=threading.get_ident(), call_chain=extended_chain)
             try:
                 return func(*args, **kwargs)
             finally:
@@ -358,6 +361,12 @@ class FunWatchRegistry:
             db = self._get_system_db()
             try:
                 with db.create_session() as session:
+                    sha = str(make_hash({
+                        "function_hash": function_hash,
+                        "function_name": function_name,
+                        "filepath": filepath,
+                        "app_id": app_id,
+                    }))
                     record = AppFunctions(
                         function_hash=function_hash,
                         function_name=function_name,
@@ -365,6 +374,7 @@ class FunWatchRegistry:
                         app_id=app_id,
                         first_seen=now,
                         last_seen=now,
+                        sha=sha,
                     )
                     db.update_insert(
                         record,
@@ -463,10 +473,28 @@ class FunWatchRegistry:
                     if task_size is not None:
                         record.task_size = task_size  # type: ignore[assignment]
                     if error_type is not None or item_error_count > 0:
+                        # When no Python exception was caught but item-level errors
+                        # were tracked via mark_failed(), derive the top-level
+                        # error_type and error_message from the dominant error type.
+                        effective_error_type = error_type
+                        effective_error_message = error_message
+                        if effective_error_type is None and item_error_types_json:
+                            try:
+                                error_types: dict[str, int] = json.loads(item_error_types_json)
+                                if error_types:
+                                    dominant_type = max(error_types, key=lambda key: error_types[key])
+                                    effective_error_type = dominant_type
+                                    if effective_error_message is None and item_error_samples_json:
+                                        samples: dict[str, list[str]] = json.loads(item_error_samples_json)
+                                        dominant_samples = samples.get(dominant_type, [])
+                                        if dominant_samples:
+                                            effective_error_message = dominant_samples[0]
+                            except (json.JSONDecodeError, TypeError, KeyError):
+                                pass
                         error_record = FunctionLogError(
                             function_log_id=log_id,
-                            error_type=error_type,
-                            error_message=error_message,
+                            error_type=effective_error_type,
+                            error_message=effective_error_message,
                             item_error_count=item_error_count,
                             item_error_types_json=item_error_types_json,
                             item_error_samples_json=item_error_samples_json,

--- a/data_collector/utilities/log/main.py
+++ b/data_collector/utilities/log/main.py
@@ -83,6 +83,67 @@ class _RawQueueHandler(QueueHandler):
         return record
 
 
+class _StructlogContextFilter(logging.Filter):
+    """Bridge structlog contextvars to stdlib LogRecords.
+
+    Reads the current structlog contextvar store and injects any bound
+    values onto the LogRecord's ``__dict__``.  This allows library modules
+    using ``logging.getLogger(__name__)`` to automatically carry the same
+    context as structlog-native loggers when called from within
+    ``@fun_watch``-decorated code.
+
+    Only sets attributes that are not already present on the record,
+    preserving any values set by the emitting code.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Inject structlog context variables onto the log record."""
+        context = structlog.contextvars.get_contextvars()
+        for key, value in context.items():
+            if getattr(record, key, None) is None:
+                setattr(record, key, value)
+        return True
+
+
+class _RequiredContextFilter(logging.Filter):
+    """Block log records missing required tracing context from persistence sinks.
+
+    Only fully-traceable records reach ``DatabaseHandler`` and ``SplunkHECHandler``.
+    The required fields (``app_id``, ``runtime``, ``function_id``, ``call_chain``)
+    are exclusively provided by ``@fun_watch`` -- no manual binding path is
+    supported.  Records without these fields still reach console output for
+    development use.
+    """
+
+    REQUIRED_FIELDS: frozenset[str] = frozenset({
+        "app_id", "runtime", "function_id", "call_chain",
+    })
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Return True only when all required context fields are present, non-None, and non-empty.
+
+        Checks three sources (in priority order):
+
+        1. LogRecord attributes -- set by ``_StructlogContextFilter`` for stdlib
+           loggers or by explicit ``setattr`` calls.
+        2. ``record.msg`` dict -- structlog-native loggers store their event dict
+           (including contextvars merged by ``merge_contextvars``) as the record
+           message before it reaches the QueueHandler.
+        3. Structlog contextvar store -- fallback for same-thread callers where
+           contextvars haven't been merged onto the record yet.
+        """
+        # For structlog records, record.msg is a dict with merged contextvars
+        message = record.msg
+        structlog_event: dict[str, object] = (
+            cast(dict[str, object], message) if isinstance(message, dict) else {}
+        )
+        context = structlog.contextvars.get_contextvars()
+        return all(
+            getattr(record, field, None) or structlog_event.get(field) or context.get(field)
+            for field in self.REQUIRED_FIELDS
+        )
+
+
 class LoggingService:
     """Configure logger + queue listener + sink routing in one place."""
 
@@ -132,7 +193,27 @@ class LoggingService:
         )
 
     def configure_logger(self) -> BoundLogger:
-        """Configure queue-driven logger and return a structlog BoundLogger."""
+        """Configure queue-driven logger and return a structlog BoundLogger.
+
+        Database and Splunk persistence requires full tracing context provided
+        exclusively by ``@fun_watch``.  The required fields (``app_id``,
+        ``runtime``, ``function_id``, ``call_chain``) are bound to structlog
+        contextvars by the framework's execution infrastructure:
+
+            - ``app_id`` and ``runtime``: bound at process startup by Manager
+              or Dramatiq worker bootstrap.
+            - ``function_id`` and ``call_chain``: bound per-invocation by
+              ``@fun_watch``.
+
+        Library modules using ``logging.getLogger(__name__)`` automatically
+        inherit this context when called from within ``@fun_watch``-decorated
+        code.  Their log records are persisted with full traceability.
+
+        Log messages emitted outside ``@fun_watch`` context appear on console
+        only and are not persisted to the Logs table or forwarded to Splunk.
+        This is by design -- untraceable records are not permitted in
+        persistence sinks.
+        """
         _StructlogConfigurator.instance().configure(self.settings)
 
         self.logger.setLevel(self.logger_level)
@@ -156,6 +237,23 @@ class LoggingService:
                     )
                 )
 
+        # Attach data quality gate to persistence sinks -- only records with
+        # full @fun_watch context (app_id, runtime, function_id, call_chain)
+        # are persisted.  Console output is unrestricted.
+        # Attach data quality gate to persistence sinks -- only records with
+        # full @fun_watch context (app_id, runtime, function_id, call_chain)
+        # are persisted.  Console output is unrestricted.
+        # The TypeError guard handles test mocking where SplunkHECHandler is
+        # replaced by MagicMock (not a valid type for isinstance).
+        required_context_filter = _RequiredContextFilter()
+        for sink in self.sinks:
+            try:
+                is_persistence_sink = isinstance(sink, (DatabaseHandler, SplunkHECHandler))
+            except TypeError:
+                is_persistence_sink = False
+            if is_persistence_sink:
+                sink.addFilter(required_context_filter)
+
         console = logging.StreamHandler()
         console.setLevel(self.logger_level)
         console.setFormatter(self._build_console_formatter())
@@ -177,6 +275,22 @@ class LoggingService:
             for handler in self.logger.handlers
         ):
             self.logger.addHandler(_RawQueueHandler(self.log_queue))
+
+        # Configure the "data_collector" parent logger so that all framework
+        # library modules using logging.getLogger(__name__) inherit handlers
+        # through Python's logger hierarchy propagation.  Without this, only
+        # the app-specific logger receives messages; library loggers like
+        # "data_collector.processing.pdf" have no handlers and their
+        # INFO/DEBUG messages are silently dropped.
+        framework_logger = logging.getLogger("data_collector")
+        if not any(
+            isinstance(handler, _RawQueueHandler) and getattr(handler, "queue", None) is self.log_queue
+            for handler in framework_logger.handlers
+        ):
+            framework_handler = _RawQueueHandler(self.log_queue)
+            framework_handler.addFilter(_StructlogContextFilter())
+            framework_logger.addHandler(framework_handler)
+            framework_logger.setLevel(min(framework_logger.level or logging.WARNING, self.logger_level))
 
         self.start()
         return cast(BoundLogger, structlog.get_logger(self.logger_name).bind())

--- a/data_collector/utilities/request.py
+++ b/data_collector/utilities/request.py
@@ -265,7 +265,7 @@ class RequestMetrics:
                 "by_proxy": by_proxy,
             }
 
-        logger.info("Request statistics: %s", stats)
+        logger.info("Request statistics", extra={"request_stats": stats})
         return stats
 
     @staticmethod
@@ -835,7 +835,7 @@ class Request:
             "error_rate_percent": round(error_rate, 2),
             "error_breakdown": error_breakdown,
         }
-        logger.info("Request statistics: %s", stats)
+        logger.info("Request statistics", extra={"request_stats": stats})
         return stats
 
     def _auto_save_response(self, url: str) -> None:


### PR DESCRIPTION
## Summary
- Add `_StructlogContextFilter` to bridge structlog contextvars to stdlib LogRecords for library module logging inheritance
- Add `_RequiredContextFilter` on DatabaseHandler/SplunkHECHandler to block incomplete records from persistence sinks (only `@fun_watch` context passes)
- Add FK constraint on `Logs.function_id` -> `AppFunctions.function_hash` (CASCADE)
- Compute SHA on AppFunctions registration, derive FunctionLogError error_type from item errors
- Extend worker call_chain, move request stats to context_json, fix examples

## Changes
- `data_collector/utilities/log/main.py` -- `_StructlogContextFilter`, `_RequiredContextFilter`, attachment logic, docstring
- `data_collector/tables/log.py` -- FK on `Logs.function_id`
- `data_collector/utilities/fun_watch.py` -- AppFunctions SHA, FunctionLogError error_type derivation, call_chain extension
- `data_collector/utilities/request.py` -- request stats to `context_json` via `extra=`
- `data_collector/examples/fun_watch/*` -- Runtime completion
- `data_collector/examples/scraping/abort_http/main.py` -- error_type/error_message in increment_failed, set_task_size
- `data_collector/examples/scraping/abort_blocker/main.py` -- error_type/error_message in increment_failed
- `data_collector/examples/scraping/books/main.py` -- set_task_size on collect

## Testing
- `ruff check` -- pass
- `pyright` -- 0 errors
- `pytest tests/unit tests/quality` -- 1532 passed
- All 9 examples (6 scraping + 3 fun_watch) run successfully
- DB verification: 0 NULL required fields in Logs, 0 NULL sha in AppFunctions, all Runtime rows complete, FunctionLogError error_type populated

## Related
- Follows WP-14 (PDF/OCR Processing) merge
- FunctionLog aggregation redesign tracked as separate work package

Generated with [Claude Code](https://claude.com/claude-code)