### PR TITLE
refactor: redesign FunctionLog error architecture

### DIFF
--- a/data_collector/examples/fun_watch/01_basic_decorator.py
+++ b/data_collector/examples/fun_watch/01_basic_decorator.py
@@ -61,9 +61,9 @@ class DemoApp(FunWatchMixin):
     def process_records(self, records: list[str]) -> int:
         """Process a batch of records, marking each as solved.
 
-        Includes a 1.5-second sleep to demonstrate that FunctionLog duration
-        columns (totals, totalm, totalh) are populated correctly for
-        functions that take measurable time.
+        Includes a 1.5-second sleep to demonstrate that FunctionLog timing
+        columns (total_elapsed_ms, average_elapsed_ms, etc.) are populated
+        correctly for functions that take measurable time.
         """
         for _record in records:
             self.logger.debug(f"processing record: {_record}")
@@ -157,7 +157,7 @@ def _print_results(db: Database, app_id: str) -> None:
         rows = session.execute(select(FunctionLog).where(FunctionLog.app_id == app_id)).scalars().all()
         for row in rows:
             print(
-                f"  id={row.id} | log_role={row.log_role} | parent_log_id={row.parent_log_id}"
+                f"  id={row.id} | log_role={row.log_role} | call_count={row.call_count}"
                 f" | solved={row.solved} | failed={row.failed} | task_size={row.task_size}"
             )
         if not rows:

--- a/data_collector/examples/fun_watch/02_database_rows.py
+++ b/data_collector/examples/fun_watch/02_database_rows.py
@@ -3,7 +3,7 @@
 Demonstrates:
     - Real LoggingService integration (Logs table inserts via DatabaseHandler)
     - Real AppFunctions registration rows (function_hash, function_name, filepath, app_id)
-    - Real FunctionLog rows (execution_order, task_size, solved, failed, timing)
+    - Real FunctionLog rows (call_count, task_size, solved, failed, timing metrics)
     - task_size auto-detection from first arg with __len__
     - task_size=None when first arg has no __len__ or no args at all
     - main_app defaults to app_id when self.main_app is not set
@@ -154,7 +154,7 @@ def _print_results(db: Database, app_ids: list[str]) -> None:
         ).scalars().all()
         for row in fl_rows:
             print(
-                f"  id={row.id} | log_role={row.log_role} | parent_log_id={row.parent_log_id}"
+                f"  id={row.id} | log_role={row.log_role} | call_count={row.call_count}"
                 f" | solved={row.solved} | failed={row.failed} | task_size={row.task_size}"
             )
         if not fl_rows:

--- a/data_collector/examples/fun_watch/03_multithreaded.py
+++ b/data_collector/examples/fun_watch/03_multithreaded.py
@@ -3,10 +3,9 @@
 Demonstrates:
     - Real LoggingService integration (Logs table inserts via DatabaseHandler)
     - ThreadPoolExecutor with multiple workers calling the same decorated method
-    - Each thread gets its own context-local FunWatchContext (no cross-talk)
-    - execution_order increments per (runtime, thread_id) pair
-    - Thread-safe counter updates (no data corruption)
-    - Per-thread FunctionLog rows with distinct thread_ids in database
+    - All threads share one aggregate FunWatchContext per function per runtime
+    - Thread-safe counter updates via _counter_lock (no data corruption)
+    - One FunctionLog row per function per runtime (aggregate model)
     - Partial failure: mark_solved() + mark_failed() with exception re-raise
 
 Requires:
@@ -38,7 +37,7 @@ from sqlalchemy import select
 from data_collector.settings.main import LogSettings
 from data_collector.tables.apps import AppFunctions, AppGroups, AppParents, Apps
 from data_collector.tables.deploy import ExampleDeploy
-from data_collector.tables.log import FunctionLog, FunctionLogError, Logs
+from data_collector.tables.log import FunctionLog, Logs
 from data_collector.tables.runtime import Runtime
 from data_collector.utilities.database.main import Database
 from data_collector.utilities.fun_watch import FunWatchMixin, FunWatchRegistry, fun_watch
@@ -161,50 +160,32 @@ def _print_results(db: Database, app_id: str) -> None:
         ).scalars().all()
         for row in log_rows:
             print(
-                f"  id={row.id} | log_role={row.log_role} | parent_log_id={row.parent_log_id}"
+                f"  id={row.id} | log_role={row.log_role} | call_count={row.call_count}"
                 f" | solved={row.solved} | failed={row.failed} | task_size={row.task_size}"
-                f" | thread_id={row.thread_id} | is_success={row.is_success}"
+                f" | is_success={row.is_success}"
             )
         if not log_rows:
             print("  (none)")
 
-        # --- Error details from FunctionLogError ---
-        log_ids: list[int] = [int(row.id) for row in log_rows]  # type: ignore[arg-type]
-        if log_ids:
-            error_rows = session.execute(
-                select(FunctionLogError).where(FunctionLogError.function_log_id.in_(log_ids))
-            ).scalars().all()
-            if error_rows:
-                print("\n=== FunctionLogError rows ===")
-                for err in error_rows:
-                    print(
-                        f"  id={err.id} | function_log_id={err.function_log_id}"
-                        f" | error_type={err.error_type}"
-                        f" | error_message={err.error_message}"
-                        f" | item_error_count={err.item_error_count}"
-                        f" | types_json={err.item_error_types_json}"
-                        f" | samples_json={err.item_error_samples_json}"
-                    )
-
-        # --- Per-thread summary table ---
+        # --- Aggregate summary ---
         if log_rows:
-            print("\n=== Per-thread summary ===")
-            print(f"  {'thread_id':>12}  {'execution_order':>15}  {'task_size':>10}  {'solved':>7}")
-            print(f"  {'-' * 12}  {'-' * 15}  {'-' * 10}  {'-' * 7}")
-            for row in sorted(log_rows, key=lambda r: (r.thread_id or 0, r.execution_order or 0)):
+            print("\n=== Aggregate summary ===")
+            print(f"  {'log_role':>12}  {'call_count':>12}  {'task_size':>10}  {'solved':>7}")
+            print(f"  {'-' * 12}  {'-' * 12}  {'-' * 10}  {'-' * 7}")
+            for row in sorted(log_rows, key=lambda r: r.id or 0):
                 print(
-                    f"  {row.thread_id or '':>12}  "
-                    f"{row.execution_order or '':>15}  "
+                    f"  {row.log_role or '':>12}  "
+                    f"{row.call_count or '':>12}  "
                     f"{row.task_size or '':>10}  "
                     f"{row.solved or '':>7}"
                 )
 
-        # --- Thread isolation verification ---
-        print("\n=== Thread isolation verification ===")
-        actual_solved = {row.solved for row in log_rows}
-        distinct_threads = {row.thread_id for row in log_rows}
-        print(f"  Actual solved values  : {sorted(actual_solved)}")
-        print(f"  Distinct thread IDs   : {len(distinct_threads)}")
+        # --- Aggregate verification ---
+        print("\n=== Aggregate verification ===")
+        total_solved = sum(row.solved or 0 for row in log_rows)
+        total_rows = len(log_rows)
+        print(f"  Total FunctionLog rows: {total_rows}")
+        print(f"  Total solved across all aggregates: {total_solved}")
 
         print("\n=== Logs rows (lifecycle events) ===")
         logs_rows = session.execute(

--- a/data_collector/examples/scraping/abort_exception/__init__.py
+++ b/data_collector/examples/scraping/abort_exception/__init__.py
@@ -1,0 +1,1 @@
+"""Exception handling demo: handled vs unhandled exceptions in thread callbacks."""

--- a/data_collector/examples/scraping/abort_exception/main.py
+++ b/data_collector/examples/scraping/abort_exception/main.py
@@ -1,22 +1,28 @@
-"""Abort signal demo: blocker DATABASE error with permanent stop.
+"""Exception handling demo: handled vs unhandled exceptions in thread callbacks.
 
-Demonstrates:
-    - ThreadedScraper with _abort_event cancelling pending futures
-    - Blocker DATABASE error (simulated) triggering immediate abort
-    - get_retry_next_run() returning None (no auto-retry for blockers)
-    - Workers cooperatively checking should_abort before work
-    - Corrected post-fatal pattern in main()
+Demonstrates two exception patterns side by side:
 
-Fetches valid book pages but simulates a DATABASE write failure on the
-3rd processed item. The DATABASE threshold (max_count=1, is_blocker=True)
-triggers immediately, sets _abort_event, and cancels remaining futures.
+1. Handled exception (try/except in app code):
+   - _scrape_page catches ValueError, calls self.logger.exception() at the
+     app call site (correct lineno, module, traceback), then increment_failed().
+   - Logs record shows traceback from the app's _scrape_page method.
+
+2. Unhandled exception (propagates to framework):
+   - _scrape_page raises RuntimeError with no try/except.
+   - wrap_with_thread_context catches it, calls logger.exception() with
+     the thread's function_id and full traceback.
+   - process_batch's except handler calls increment_failed() (counter only).
+   - Logs record shows traceback from the framework wrapper.
+
+Both tracebacks are stored in Logs.context_json under the "exception" key.
+Query: SELECT * FROM logs WHERE log_level >= 40 to inspect.
 
 Requires:
     DC_DB_MAIN_USERNAME, DC_DB_MAIN_PASSWORD, DC_DB_MAIN_DATABASENAME,
     DC_DB_MAIN_IP, DC_DB_MAIN_PORT environment variables.
 
 Run:
-    python -m data_collector.examples run scraping/abort_blocker/main
+    python -m data_collector.examples run scraping/abort_exception/main
 """
 
 from __future__ import annotations
@@ -50,17 +56,22 @@ _REQUIRED_ENV = (
     "DC_DB_MAIN_IP", "DC_DB_MAIN_PORT",
 )
 
-# Item index at which to simulate a DATABASE error
-_SIMULATE_DB_ERROR_AT = 2
+# Item indices at which to trigger each exception type
+_SIMULATE_HANDLED_AT = 2
+_SIMULATE_UNHANDLED_AT = 4
 
 
-class AbortBlocker(ThreadedScraper):
-    """Multi-threaded scraper demonstrating blocker abort via _abort_event.
+def _parse_books(content: bytes) -> list[Any]:
+    """Simulate parsing that raises ValueError on bad content."""
+    raise ValueError("Malformed HTML: unexpected <script> tag in catalogue row 3")
 
-    Fetches valid book pages but simulates a DATABASE write failure after
-    processing a few items. The DATABASE threshold triggers immediately
-    (max_count=1, is_blocker=True), sets _abort_event, and process_batch()
-    cancels remaining futures with executor.shutdown(cancel_futures=True).
+
+class AbortException(ThreadedScraper):
+    """Multi-threaded scraper demonstrating handled and unhandled exception patterns.
+
+    After a few successful items:
+    - Item N triggers a handled ValueError (caught in try/except, logged by app).
+    - Item M triggers an unhandled RuntimeError (caught by wrap_with_thread_context).
     """
 
     base_url = "https://books.toscrape.com"
@@ -68,8 +79,10 @@ class AbortBlocker(ThreadedScraper):
     def __init__(self, database: Database, **kwargs: Any) -> None:
         super().__init__(database, **kwargs)
         self.parser = Parser()
-        self._simulated_error = False
+        self._handled_triggered = False
+        self._unhandled_triggered = False
         self._simulate_lock = threading.Lock()
+        self._call_counter = 0
 
     @fun_watch
     def prepare_list(self) -> None:
@@ -80,7 +93,7 @@ class AbortBlocker(ThreadedScraper):
         ]
         self.list_size = len(self.work_list)
         self.logger.info("Work list prepared", extra={"list_size": self.list_size})
-        print(f"  Prepared {self.list_size} URLs (all valid)")
+        print(f"  Prepared {self.list_size} URLs")
 
     @fun_watch
     def collect(self) -> None:
@@ -90,33 +103,45 @@ class AbortBlocker(ThreadedScraper):
         self.process_batch(self.work_list, self._scrape_page, max_workers=2)
 
     def _scrape_page(self, item: Any, instance_id: int) -> None:
-        """Fetch one page; simulate DATABASE error on the 3rd processed item."""
+        """Fetch one page; simulate handled and unhandled exceptions."""
         if self.should_abort:
             return
 
         request = self.create_worker_request()
         response = request.get(item)
         if response is None:
-            print(f"  FAILED [{instance_id}]: {item}")
             self.logger.error(f"Connection failed: {item}")
             self.increment_failed(error_category=request.get_error_category())
             return
 
-        books = self.parser.parse_catalogue(response.content)
-
-        # Simulate DATABASE error after a few successful items
+        # Decide which failure mode to simulate based on call order
         with self._simulate_lock:
-            processed = self.solved + self.failed
-            should_simulate = not self._simulated_error and processed >= _SIMULATE_DB_ERROR_AT
-            if should_simulate:
-                self._simulated_error = True
+            call_number = self._call_counter
+            self._call_counter += 1
+            trigger_handled = not self._handled_triggered and call_number == _SIMULATE_HANDLED_AT
+            trigger_unhandled = not self._unhandled_triggered and call_number == _SIMULATE_UNHANDLED_AT
+            if trigger_handled:
+                self._handled_triggered = True
+            if trigger_unhandled:
+                self._unhandled_triggered = True
 
-        if should_simulate:
-            print(f"  SIMULATING DATABASE ERROR [{instance_id}]: {item}")
-            self.logger.error(f"Database write failure: {item}")
-            self.increment_failed(error_category=ErrorCategory.DATABASE)
+        # --- Pattern 1: Handled exception (app catches, logs, increments counter) ---
+        if trigger_handled:
+            print(f"  HANDLED EXCEPTION [{instance_id}]: {item}")
+            try:
+                _parse_books(response.content)
+            except ValueError:
+                self.logger.exception(f"Parse error on {item}")
+                self.increment_failed(error_category=ErrorCategory.PARSE)
             return
 
+        # --- Pattern 2: Unhandled exception (propagates to framework) ---
+        if trigger_unhandled:
+            print(f"  UNHANDLED EXCEPTION [{instance_id}]: {item}")
+            raise RuntimeError(f"Unexpected response format from {item}")
+
+        # Normal processing
+        books = self.parser.parse_catalogue(response.content)
         if books:
             self.store(books)
         print(f"  OK [{instance_id}]: {item} ({len(books)} books)")
@@ -169,7 +194,7 @@ def _register_app(database: Database, app_info: AppInfo) -> None:
 
 
 def _update_runtime(
-    database: Database, runtime: str, start_time: datetime, scraper: AbortBlocker | None,
+    database: Database, runtime: str, start_time: datetime, scraper: AbortException | None,
 ) -> None:
     """Finalize the Runtime record with end time and counters."""
     end_time = datetime.now(UTC)
@@ -194,7 +219,7 @@ def _update_runtime(
 
 
 def main() -> None:
-    """Blocker abort demo: simulated DATABASE error triggers permanent stop."""
+    """Exception handling demo: handled vs unhandled exceptions in thread callbacks."""
     missing = [v for v in _REQUIRED_ENV if not os.environ.get(v)]
     if missing:
         print(f"Skipping: DB env vars not set: {', '.join(missing)}")
@@ -202,7 +227,6 @@ def main() -> None:
 
     FunWatchRegistry.reset()
 
-    # Deploy all tables into dc_example schema (non-destructive) + codebook seed data
     deploy = ExampleDeploy()
     deploy.create_tables()
     deploy.populate_tables()
@@ -235,13 +259,14 @@ def main() -> None:
         session.merge(Runtime(runtime=runtime, app_id=app_id, start_time=start_time))
         session.commit()
 
-    print("\n--- Abort Blocker Demo: DATABASE Error ---")
-    print(f"Expected: ~{_SIMULATE_DB_ERROR_AT} OK, then simulated DATABASE error triggers blocker abort\n")
+    print("\n--- Exception Handling Demo: Handled vs Unhandled ---")
+    print(f"  Item {_SIMULATE_HANDLED_AT}: handled ValueError (app catches, logs traceback)")
+    print(f"  Item {_SIMULATE_UNHANDLED_AT}: unhandled RuntimeError (framework catches, logs traceback)\n")
 
-    scraper: AbortBlocker | None = None
+    scraper: AbortException | None = None
     try:
         metrics = RequestMetrics()
-        scraper = AbortBlocker(
+        scraper = AbortException(
             database, logger=logger, runtime=runtime, app_id=app_id, metrics=metrics, max_workers=2,
             category_thresholds=DEFAULT_CATEGORY_THRESHOLDS,
         )
@@ -249,7 +274,6 @@ def main() -> None:
         scraper.collect()
         scraper.fatal_check()
 
-        # Corrected post-fatal pattern: use get_retry_next_run() when fatal
         if scraper.should_abort:
             scraper.next_run = scraper.get_retry_next_run()
             if scraper.next_run is not None:
@@ -258,12 +282,11 @@ def main() -> None:
                 print("\n  BLOCKER: no retry, manual intervention required")
         else:
             scraper.set_next_run()
-            print(f"\n  Normal completion: next_run={scraper.next_run}")
 
         print(f"\n  Results: solved={scraper.solved}, failed={scraper.failed}")
-        print(f"  list_size={scraper.list_size}, max_workers={scraper.max_workers}")
         print(f"  fatal_flag={scraper.fatal_flag}")
-        print(f"  fatal_msg={scraper.fatal_msg or 'none'}")
+        print("  Check Logs table: SELECT * FROM dc_example.logs WHERE log_level >= 40")
+        print("  Both records should have traceback in context_json")
 
         scraper.update_progress(force=True)
         update_app_status(

--- a/data_collector/examples/scraping/abort_http/main.py
+++ b/data_collector/examples/scraping/abort_http/main.py
@@ -102,21 +102,15 @@ class AbortHttp(BaseScraper):
             response = self.request.get(url)
             if response is None:
                 print(f"  FAILED (connection): {url}")
-                self.increment_failed(
-                    error_category=self.request.get_error_category(),
-                    error_type="ConnectionError",
-                    error_message=f"{url}: connection failed",
-                )
+                self.logger.error(f"Connection failed: {url}")
+                self.increment_failed(error_category=self.request.get_error_category())
                 self.update_progress()
                 continue
 
             if response.status_code < 200 or response.status_code >= 300:
                 print(f"  FAILED (HTTP {response.status_code}): {url}")
-                self.increment_failed(
-                    error_category=ErrorCategory.HTTP,
-                    error_type=f"HTTP_{response.status_code}",
-                    error_message=f"{url}: HTTP {response.status_code}",
-                )
+                self.logger.error(f"HTTP {response.status_code}: {url}")
+                self.increment_failed(error_category=ErrorCategory.HTTP)
                 self.update_progress()
                 continue
 

--- a/data_collector/orchestration/retention.py
+++ b/data_collector/orchestration/retention.py
@@ -21,7 +21,7 @@ from sqlalchemy import delete, func, select
 from data_collector.settings.manager import ManagerSettings
 from data_collector.tables.apps import AppGroups, AppParents, Apps
 from data_collector.tables.command_log import CommandLog
-from data_collector.tables.log import FunctionLog, FunctionLogError, Logs
+from data_collector.tables.log import FunctionLog, Logs
 from data_collector.tables.runtime import Runtime
 from data_collector.utilities.database.main import Database
 
@@ -29,7 +29,7 @@ from data_collector.utilities.database.main import Database
 class LogRetentionCleaner:
     """Delete log and runtime records older than configured retention thresholds.
 
-    Handles operational table hygiene: function_log, function_log_error,
+    Handles operational table hygiene: function_log,
     logs, runtime, command_log, and app directory purge.  File storage
     retention is a separate concern handled by ``StorageJanitor``.
 
@@ -54,21 +54,13 @@ class LogRetentionCleaner:
         """Delete records exceeding their retention period.
 
         Tables cleaned (in order to respect FK constraints):
-        1. ``function_log_error`` -- FK CASCADE from function_log, but explicit
-           deletion is safer for databases without CASCADE configured.
-        2. ``function_log``
-        3. ``logs``
-        4. ``runtime``
-        5. ``command_log``
+        1. ``function_log``
+        2. ``logs``
+        3. ``runtime``
+        4. ``command_log``
         """
         now = datetime.now(UTC)
 
-        self._delete_older_than(
-            FunctionLogError,
-            FunctionLogError.date_created,
-            now - timedelta(days=self._settings.retention_function_log_days),
-            "function_log_error",
-        )
         self._delete_older_than(
             FunctionLog,
             FunctionLog.date_created,

--- a/data_collector/scraping/async_scraper.py
+++ b/data_collector/scraping/async_scraper.py
@@ -11,10 +11,12 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
 from typing import Any
 
 from data_collector.scraping.base import BaseScraper, CategoryThreshold
 from data_collector.utilities.database.main import Database
+from data_collector.utilities.fun_watch import FunWatchContext, FunWatchRegistry
 from data_collector.utilities.request import RequestMetrics
 
 
@@ -72,9 +74,10 @@ class AsyncScraper(BaseScraper):
     ) -> None:
         """Execute async worker for each item with semaphore control.
 
-        Uses a double-check pattern on fatal_flag: once before semaphore
-        acquisition (fast path) and once after (in case flag was set while
-        waiting).
+        Registers the worker callback in AppFunctions and creates an aggregate
+        FunctionLog row with ``log_role='thread'``.  Each coroutine binds the
+        thread context so that ``increment_solved()`` / ``increment_failed()``
+        update the thread's FunctionLog row.
 
         Args:
             items: Work items to process concurrently.
@@ -85,18 +88,61 @@ class AsyncScraper(BaseScraper):
         effective_concurrency = max_concurrency if max_concurrency is not None else self.max_concurrency
         semaphore = asyncio.Semaphore(effective_concurrency)
 
+        registry = FunWatchRegistry.instance()
+        parent_context = registry.try_get_active_context()
+
+        thread_context: FunWatchContext | None = None
+        if parent_context is not None:
+            thread_context, _thread_function_hash = registry.register_thread(
+                worker, self.app_id, self.runtime,
+                main_app=getattr(self, "main_app", None),
+                caller_log_id=parent_context.log_id,
+            )
+            thread_context.task_size = len(items)
+
         async def _wrapper(item: Any, instance_id: int) -> None:
             if self.fatal_flag:
                 return
             async with semaphore:
                 if self.fatal_flag:
                     return
-                await worker(item, instance_id)
+                if thread_context is not None:
+                    token = registry.bind_context(thread_context)
+                    invocation_start = datetime.now(UTC)
+                    try:
+                        await worker(item, instance_id)
+                    finally:
+                        duration_ms = (datetime.now(UTC) - invocation_start).total_seconds() * 1000.0
+                        thread_context.record_invocation_duration(duration_ms)
+                        registry.unbind_context(token)
+                else:
+                    await worker(item, instance_id)
             if track_progress:
                 self.update_progress()
 
         tasks = [_wrapper(item, idx) for idx, item in enumerate(items)]
         await asyncio.gather(*tasks)
+
+        if thread_context is not None:
+            solved, failed = thread_context.snapshot()
+            if parent_context is not None:
+                parent_context.mark_solved(solved)
+                if failed > 0:
+                    parent_context.mark_failed(failed)
+            timing = thread_context.timing_snapshot()
+            registry.complete_function_log(
+                log_id=thread_context.log_id,
+                solved=solved,
+                failed=failed,
+                call_count=len(items),
+                end_time=datetime.now(UTC),
+                total_elapsed_ms=timing[0],
+                average_elapsed_ms=timing[1],
+                median_elapsed_ms=timing[2],
+                min_elapsed_ms=timing[3],
+                max_elapsed_ms=timing[4],
+                task_size=thread_context.task_size,
+            )
 
     async def store_async(self, records: list[Any]) -> None:
         """Serialized async wrapper for store().

--- a/data_collector/scraping/base.py
+++ b/data_collector/scraping/base.py
@@ -216,16 +216,12 @@ class BaseScraper(FunWatchMixin):
         count: int = 1,
         *,
         error_category: ErrorCategory | str | None = None,
-        error_type: str | None = None,
-        error_message: str | None = None,
     ) -> None:
         """Thread-safe increment of failed counter with FunWatchContext forwarding.
 
         Args:
             count: Number to add (default 1).
             error_category: ErrorCategory for per-category threshold evaluation.
-            error_type: Optional error classification for FunWatchContext.
-            error_message: Optional error description for FunWatchContext.
         """
         with self._progress_lock:
             self.failed += count
@@ -238,7 +234,7 @@ class BaseScraper(FunWatchMixin):
                 )
         active_context = FunWatchRegistry.instance().try_get_active_context()
         if active_context is not None:
-            active_context.mark_failed(count, error_type=error_type, error_message=error_message)
+            active_context.mark_failed(count)
         self._check_failure_threshold()
 
     def _check_failure_threshold(self) -> None:

--- a/data_collector/scraping/threaded.py
+++ b/data_collector/scraping/threaded.py
@@ -11,11 +11,12 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import UTC, datetime
 from typing import Any
 
 from data_collector.scraping.base import BaseScraper, CategoryThreshold
 from data_collector.utilities.database.main import Database
-from data_collector.utilities.fun_watch import FunWatchRegistry
+from data_collector.utilities.fun_watch import FunWatchContext, FunWatchRegistry
 from data_collector.utilities.request import Request, RequestMetrics
 
 
@@ -69,13 +70,14 @@ class ThreadedScraper(BaseScraper):
     ) -> None:
         """Execute worker callable for each item using a ThreadPoolExecutor.
 
-        Propagates FunWatchContext to worker threads when an active context
-        exists. Checks ``_abort_event`` after each completed future and
-        cancels pending futures when a fatal threshold is breached.
+        Registers the worker callback in AppFunctions and creates an aggregate
+        FunctionLog row with ``log_role='thread'``.  Worker threads bind the
+        thread context (not the parent) so that ``increment_solved()`` /
+        ``increment_failed()`` update the thread's FunctionLog row.  Errors
+        logged inside workers carry the thread's ``function_id`` in structlog.
 
-        Workers should check ``self.should_abort`` before expensive
-        operations (HTTP requests, captcha solves) for cooperative
-        cancellation of in-flight work.
+        After all workers complete, solved/failed counters are propagated back
+        to the caller's (parent) aggregate context.
 
         Args:
             items: Work items to process in parallel.
@@ -85,14 +87,28 @@ class ThreadedScraper(BaseScraper):
         """
         effective_workers = max_workers if max_workers is not None else self.max_workers
         registry = FunWatchRegistry.instance()
-        has_context = registry.try_get_active_context() is not None
+        parent_context = registry.try_get_active_context()
+
+        thread_context: FunWatchContext | None = None
+        thread_function_hash: str | None = None
+        if parent_context is not None:
+            thread_context, thread_function_hash = registry.register_thread(
+                worker, self.app_id, self.runtime,
+                main_app=getattr(self, "main_app", None),
+                caller_log_id=parent_context.log_id,
+            )
+            thread_context.task_size = len(items)
 
         with ThreadPoolExecutor(max_workers=effective_workers) as executor:
+            wrapped_worker = (
+                registry.wrap_with_thread_context(
+                    worker, thread_context, thread_function_hash, application_logger=self.logger,
+                )
+                if thread_context is not None and thread_function_hash is not None
+                else worker
+            )
             futures = {
-                executor.submit(
-                    registry.wrap_with_active_context(worker) if has_context else worker,
-                    item, idx,
-                ): item
+                executor.submit(wrapped_worker, item, idx): item
                 for idx, item in enumerate(items)
             }
             for future in as_completed(futures):
@@ -102,10 +118,33 @@ class ThreadedScraper(BaseScraper):
                 try:
                     future.result()
                 except Exception:
-                    self.logger.exception("Worker exception for item %s", futures[future])
-                    self.increment_failed()
+                    with self._progress_lock:
+                        self.failed += 1
+                        self._consecutive_failures += 1
+                    self._check_failure_threshold()
                 if track_progress:
                     self.update_progress()
+
+        if thread_context is not None:
+            solved, failed = thread_context.snapshot()
+            if parent_context is not None:
+                parent_context.mark_solved(solved)
+                if failed > 0:
+                    parent_context.mark_failed(failed)
+            timing = thread_context.timing_snapshot()
+            registry.complete_function_log(
+                log_id=thread_context.log_id,
+                solved=solved,
+                failed=failed,
+                call_count=len(items),
+                end_time=datetime.now(UTC),
+                total_elapsed_ms=timing[0],
+                average_elapsed_ms=timing[1],
+                median_elapsed_ms=timing[2],
+                min_elapsed_ms=timing[3],
+                max_elapsed_ms=timing[4],
+                task_size=thread_context.task_size,
+            )
 
     def create_worker_request(self) -> Request:
         """Create a Request instance for a worker thread.

--- a/data_collector/tables/__init__.py
+++ b/data_collector/tables/__init__.py
@@ -20,7 +20,7 @@ from data_collector.tables.captcha import (
     CodebookCaptchaSolveStatus,
 )
 from data_collector.tables.command_log import CommandLog
-from data_collector.tables.log import CodebookLogLevel, FunctionLog, FunctionLogError, Logs
+from data_collector.tables.log import CodebookLogLevel, FunctionLog, Logs
 from data_collector.tables.notifications import CodebookAlertSeverity
 from data_collector.tables.pipeline import (
     CodebookPipelineStage,
@@ -66,7 +66,6 @@ __all__ = [
     "Events",
     "FatalFlag",
     "FunctionLog",
-    "FunctionLogError",
     "Logs",
     "PipelineTask",
     "ProxyBlacklist",

--- a/data_collector/tables/captcha.py
+++ b/data_collector/tables/captcha.py
@@ -3,7 +3,7 @@
 CaptchaLog records every captcha task submitted to a provider, tracking
 cost, timing, status, and correctness feedback. CaptchaLogError stores
 provider error details (error code, description, category) in a separate
-one-to-one table, following the FunctionLog/FunctionLogError split pattern.
+one-to-one table, following the CaptchaLog/CaptchaLogError split pattern.
 
 These are operational log tables -- they do not follow DataTableMixin
 (no sha, archive, date_modified columns).
@@ -96,7 +96,7 @@ class CaptchaLogError(Base):
     returns an error (status FAILED or TIMED_OUT). Successful solves have
     no CaptchaLogError record.
 
-    Follows the FunctionLog/FunctionLogError split pattern
+    Follows the CaptchaLog/CaptchaLogError split pattern
     (``data_collector.tables.log``).
     """
 

--- a/data_collector/tables/log.py
+++ b/data_collector/tables/log.py
@@ -1,7 +1,19 @@
 """Logging ORM tables and related codebooks."""
 
 
-from sqlalchemy import BigInteger, Boolean, Column, DateTime, ForeignKey, Integer, String, UnicodeText, func, text
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    UnicodeText,
+    UniqueConstraint,
+    func,
+    text,
+)
 
 from data_collector.tables.apps import AppFunctions, Apps
 from data_collector.tables.runtime import Runtime
@@ -61,9 +73,12 @@ class Logs(Base):
 
 
 class FunctionLog(Base):
-    """Per-invocation execution metrics recorded by @fun_watch."""
+    """Per-function-per-runtime aggregate execution metrics recorded by @fun_watch."""
 
     __tablename__ = "function_log"
+    __table_args__ = (
+        UniqueConstraint("function_hash", "runtime", name="uq_function_log_function_runtime"),
+    )
 
     id = auto_increment_column()
     function_hash = Column(
@@ -71,13 +86,10 @@ class FunctionLog(Base):
         ForeignKey(AppFunctions.function_hash, ondelete="CASCADE"),
         index=True,
     )
-    execution_order = Column(BigInteger, nullable=False)
-    thread_execution_order = Column(BigInteger, nullable=False, server_default=text("0"))
-    log_role = Column(String(16), nullable=False, server_default=text("'single'"))
-    parent_log_id = Column(BigInteger)
+    log_role = Column(String(16), nullable=False, server_default=text("'function'"))
     main_app = Column(String(64), index=True)
     app_id = Column(String(64), index=True)
-    thread_id = Column(BigInteger)
+    call_count = Column(BigInteger, nullable=False, server_default=text("1"))
     task_size = Column(BigInteger)
     solved = Column(Integer, server_default=text("0"))
     failed = Column(Integer, server_default=text("0"))
@@ -85,36 +97,18 @@ class FunctionLog(Base):
     is_success = Column(Boolean, nullable=False, server_default=text("true"))
     start_time = Column(DateTime(timezone=True))
     end_time = Column(DateTime(timezone=True))
-    totals = Column(Integer)
-    totalm = Column(Integer)
-    totalh = Column(Integer)
+    total_elapsed_ms = Column(BigInteger, doc="Sum of all invocation durations in milliseconds")
+    average_elapsed_ms = Column(Integer, doc="Mean invocation duration in milliseconds")
+    median_elapsed_ms = Column(Integer, doc="P50 invocation duration in milliseconds")
+    min_elapsed_ms = Column(Integer, doc="Fastest invocation duration in milliseconds")
+    max_elapsed_ms = Column(Integer, doc="Slowest invocation duration in milliseconds")
+    caller_log_id = Column(
+        BigInteger,
+        doc="Self-referential FK to the caller's FunctionLog id. Set on log_role='thread' rows only.",
+    )
     runtime = Column(
         String(64),
         ForeignKey(Runtime.runtime, ondelete="CASCADE"),
         index=True,
     )
-    date_created = Column(DateTime(timezone=True), server_default=func.now())
-
-
-class FunctionLogError(Base):
-    """Error details for failed @fun_watch invocations."""
-
-    __tablename__ = "function_log_error"
-
-    id = auto_increment_column()
-    function_log_id = Column(
-        BigInteger,
-        ForeignKey(FunctionLog.id, ondelete="CASCADE"),
-        nullable=False,
-        unique=True,
-        index=True,
-    )
-    error_type = Column(String(256), doc="Exception class name")
-    error_message = Column(UnicodeText, doc="Exception message string")
-    item_error_count = Column(
-        Integer, nullable=False, server_default=text("0"),
-        doc="Count of items with typed errors via mark_failed(error_type=...)",
-    )
-    item_error_types_json = Column(UnicodeText, doc="JSON: error type -> count mapping")
-    item_error_samples_json = Column(UnicodeText, doc="JSON: error type -> sample messages (max 5 per type)")
     date_created = Column(DateTime(timezone=True), server_default=func.now())

--- a/data_collector/utilities/fun_watch.py
+++ b/data_collector/utilities/fun_watch.py
@@ -1,7 +1,7 @@
 """@fun_watch decorator for function-level performance monitoring.
 
-Provides automatic function registration (AppFunctions) and per-invocation
-metric recording (FunctionLog) with thread-safe context-local counters.
+Provides automatic function registration (AppFunctions) and per-function-per-runtime
+aggregate metric recording (FunctionLog) with thread-safe context-local counters.
 Binds ``function_id`` into structlog context for log correlation.
 """
 
@@ -9,8 +9,8 @@ from __future__ import annotations
 
 import functools
 import inspect
-import json
 import logging
+import statistics
 import sys
 import threading
 from collections.abc import Callable
@@ -21,13 +21,11 @@ from pathlib import Path
 from typing import Any, TypeVar
 
 import structlog  # type: ignore[import-untyped]
-from sqlalchemy import select
 
 from data_collector.settings.main import MainDatabaseSettings
 from data_collector.tables.apps import AppFunctions
-from data_collector.tables.log import FunctionLog, FunctionLogError
+from data_collector.tables.log import FunctionLog
 from data_collector.utilities.database.main import Database
-from data_collector.utilities.functions.math import get_totalh, get_totalm, get_totals
 from data_collector.utilities.functions.runtime import make_hash
 
 logger = structlog.get_logger(__name__)
@@ -82,67 +80,71 @@ def _get_class_lineno(cls: type, fallback: int) -> int:
 
 
 class FunWatchContext:
-    """Per-invocation counters used by the ``@fun_watch`` wrapper.
+    """Aggregate counters for a single function within a single runtime.
 
-    Application code updates the active invocation context through
-    ``self._fun_watch.mark_solved()`` / ``self._fun_watch.mark_failed()``.
-    The active context is bound using context-local state.
+    One context exists per (function_hash, runtime) pair. Application code
+    updates the active context through ``self._fun_watch.mark_solved()`` /
+    ``self._fun_watch.mark_failed()``. The context accumulates metrics
+    across all invocations of that function within the runtime.
     """
 
-    _MAX_ERROR_SAMPLES: int = 5
-
-    __slots__ = ("solved", "failed", "task_size", "log_id", "_counter_lock", "_error_types", "_error_samples")
+    __slots__ = (
+        "solved", "failed", "task_size", "log_id", "call_count",
+        "first_start_time", "_invocation_durations", "_counter_lock",
+    )
 
     def __init__(self, task_size: int | None = None) -> None:
         self.solved: int = 0
         self.failed: int = 0
         self.task_size: int | None = task_size
         self.log_id: int | None = None
+        self.call_count: int = 0
+        self.first_start_time: datetime | None = None
+        self._invocation_durations: list[float] = []
         self._counter_lock = threading.Lock()
-        self._error_types: dict[str, int] = {}
-        self._error_samples: dict[str, list[str]] = {}
+
+    def increment_call_count(self) -> None:
+        """Atomically increment call_count."""
+        with self._counter_lock:
+            self.call_count += 1
+
+    def record_invocation_duration(self, duration_ms: float) -> None:
+        """Record the duration of a single invocation in milliseconds."""
+        with self._counter_lock:
+            self._invocation_durations.append(duration_ms)
+
+    def timing_snapshot(self) -> tuple[int, int, int, int, int]:
+        """Return an atomic snapshot of timing statistics.
+
+        Returns:
+            Tuple of (total_elapsed_ms, average_elapsed_ms, median_elapsed_ms,
+            min_elapsed_ms, max_elapsed_ms). All zeros when no durations recorded.
+        """
+        with self._counter_lock:
+            if not self._invocation_durations:
+                return 0, 0, 0, 0, 0
+            durations = list(self._invocation_durations)
+        total_elapsed_ms = int(sum(durations))
+        average_elapsed_ms = int(total_elapsed_ms / len(durations))
+        median_elapsed_ms = int(statistics.median(durations))
+        min_elapsed_ms = int(min(durations))
+        max_elapsed_ms = int(max(durations))
+        return total_elapsed_ms, average_elapsed_ms, median_elapsed_ms, min_elapsed_ms, max_elapsed_ms
 
     def mark_solved(self, count: int = 1) -> None:
         """Increment the solved counter."""
         with self._counter_lock:
             self.solved += count
 
-    def mark_failed(
-        self,
-        count: int = 1,
-        *,
-        error_type: str | None = None,
-        error_message: str | None = None,
-    ) -> None:
-        """Increment the failed counter with optional error detail aggregation."""
+    def mark_failed(self, count: int = 1) -> None:
+        """Increment the failed counter."""
         with self._counter_lock:
             self.failed += count
-            if error_type is not None:
-                self._error_types[error_type] = self._error_types.get(error_type, 0) + count
-                if error_message is not None:
-                    samples = self._error_samples.setdefault(error_type, [])
-                    if len(samples) < self._MAX_ERROR_SAMPLES:
-                        samples.append(error_message)
 
     def snapshot(self) -> tuple[int, int]:
         """Return an atomic snapshot of solved and failed counters."""
         with self._counter_lock:
             return self.solved, self.failed
-
-    def error_snapshot(self) -> tuple[int, str | None, str | None]:
-        """Return an atomic snapshot of item error details.
-
-        Returns:
-            Tuple of (item_error_count, item_error_types_json, item_error_samples_json).
-            JSON strings are None when no typed errors were recorded.
-        """
-        with self._counter_lock:
-            if not self._error_types:
-                return 0, None, None
-            item_error_count = sum(self._error_types.values())
-            types_json = json.dumps(self._error_types, separators=(",", ":"))
-            samples_json = json.dumps(self._error_samples, separators=(",", ":")) if self._error_samples else None
-            return item_error_count, types_json, samples_json
 
 
 class _FunWatchContextProxy:
@@ -157,15 +159,9 @@ class _FunWatchContextProxy:
         """Forward solved counter updates to the active invocation context."""
         self._registry.get_active_context().mark_solved(count)
 
-    def mark_failed(
-        self,
-        count: int = 1,
-        *,
-        error_type: str | None = None,
-        error_message: str | None = None,
-    ) -> None:
+    def mark_failed(self, count: int = 1) -> None:
         """Forward failed counter updates to the active invocation context."""
-        self._registry.get_active_context().mark_failed(count, error_type=error_type, error_message=error_message)
+        self._registry.get_active_context().mark_failed(count)
 
     def set_task_size(self, size: int) -> None:
         """Set the task_size on the active invocation context."""
@@ -188,7 +184,7 @@ class FunWatchMixin:
 
 
 class FunWatchRegistry:
-    """Thread-safe singleton that manages function registration, counters, and DB access.
+    """Thread-safe singleton that manages function registration, aggregate contexts, and DB access.
 
     All mutable state lives here instead of in module-level globals.
     Access the singleton via ``FunWatchRegistry.instance()``.
@@ -201,10 +197,8 @@ class FunWatchRegistry:
         self._registered_functions: dict[str, bool] = {}
         self._registration_lock = threading.Lock()
 
-        self._global_counters: dict[str, int] = {}
-        self._thread_counters: dict[tuple[str, int], int] = {}
-        self._counter_lock = threading.Lock()
-        self._current_runtime: str | None = None
+        self._aggregate_contexts: dict[tuple[str, str], FunWatchContext] = {}
+        self._aggregate_lock = threading.Lock()
 
         self._default_lifecycle_log_level: int = logging.DEBUG
 
@@ -263,27 +257,6 @@ class FunWatchRegistry:
         """
         self._default_lifecycle_log_level = level
 
-    def next_execution_order(self, runtime_id: str, thread_id: int) -> tuple[int, int]:
-        """Return and increment (global_order, thread_order) execution ordinals.
-
-        global_order increments across all threads (chronological).
-        thread_order increments independently per thread.
-
-        Clears stale counters when a new runtime_id is detected to prevent
-        unbounded memory growth in long-running processes.
-        """
-        thread_key = (runtime_id, thread_id)
-        with self._counter_lock:
-            if self._current_runtime is not None and self._current_runtime != runtime_id:
-                self._global_counters.clear()
-                self._thread_counters.clear()
-            self._current_runtime = runtime_id
-            global_order = self._global_counters.get(runtime_id, 0) + 1
-            self._global_counters[runtime_id] = global_order
-            thread_order = self._thread_counters.get(thread_key, 0) + 1
-            self._thread_counters[thread_key] = thread_order
-        return global_order, thread_order
-
     def bind_context(self, context: FunWatchContext) -> Token[FunWatchContext | None]:
         """Bind invocation context for the current execution flow."""
         return self._active_context.set(context)
@@ -328,19 +301,125 @@ class FunWatchRegistry:
 
         return wrapped
 
+    def wrap_with_thread_context(
+        self,
+        func: Callable[..., T],
+        thread_context: FunWatchContext,
+        thread_function_hash: str,
+        application_logger: Any = None,
+    ) -> Callable[..., T]:
+        """Wrap callable so worker threads use a dedicated thread aggregate context.
+
+        Unlike ``wrap_with_active_context`` which propagates the parent context,
+        this binds the ``thread_context`` so that ``mark_solved()`` /
+        ``mark_failed()`` update the thread callback's aggregate FunctionLog row.
+        Per-invocation duration is measured and recorded on the thread context.
+        Structlog contextvars are propagated from the parent for log correlation,
+        with ``function_id`` overridden to the thread's function hash so that
+        error logs point to the correct FunctionLog row.
+
+        Args:
+            func: The worker callable to wrap.
+            thread_context: Aggregate context for the thread callback.
+            thread_function_hash: Function hash for structlog function_id binding.
+            application_logger: App-level logger with DatabaseHandler attached.
+                When provided, unhandled exceptions are persisted to the Logs table.
+                Falls back to the module-level logger (stderr only) when None.
+        """
+        parent_structlog_context = structlog.contextvars.get_contextvars()
+        exception_logger = application_logger if application_logger is not None else logger
+
+        @functools.wraps(func)
+        def wrapped(*args: Any, **kwargs: Any) -> T:
+            token = self.bind_context(thread_context)
+            structlog.contextvars.bind_contextvars(**parent_structlog_context)
+            parent_chain = parent_structlog_context.get("call_chain", "")
+            worker_name = getattr(func, "__qualname__", None) or getattr(func, "__name__", "worker")
+            extended_chain = f"{parent_chain} -> {worker_name}" if parent_chain else worker_name
+            structlog.contextvars.bind_contextvars(
+                thread_id=threading.get_ident(),
+                call_chain=extended_chain,
+                function_id=thread_function_hash,
+                function_name=worker_name,
+            )
+            invocation_start = datetime.now(UTC)
+            try:
+                return func(*args, **kwargs)
+            except Exception as exc:
+                thread_context.mark_failed(1)
+                traceback_frame = exc.__traceback__
+                exception_module_path = ""
+                exception_lineno = 0
+                if traceback_frame is not None:
+                    while traceback_frame.tb_next is not None:
+                        traceback_frame = traceback_frame.tb_next
+                    exception_module_path = traceback_frame.tb_frame.f_code.co_filename
+                    exception_lineno = traceback_frame.tb_lineno
+                exception_logger.exception(
+                    f"Unhandled exception in thread callback {worker_name}",
+                    module_name=Path(exception_module_path).name if exception_module_path else None,
+                    module_path=exception_module_path or None,
+                    lineno=exception_lineno or None,
+                )
+                raise
+            finally:
+                duration_ms = (datetime.now(UTC) - invocation_start).total_seconds() * 1000.0
+                thread_context.record_invocation_duration(duration_ms)
+                structlog.contextvars.unbind_contextvars(*parent_structlog_context.keys(), "function_name")
+                self.unbind_context(token)
+
+        return wrapped
+
     def try_get_active_context(self) -> FunWatchContext | None:
         """Return the currently active context, or None if none is bound."""
         return self._active_context.get()
-
-    def get_parent_log_id(self) -> int | None:
-        """Return the log_id of the currently active context, or None."""
-        context = self._active_context.get()
-        return context.log_id if context is not None else None
 
     def ensure_context_proxy(self, instance: Any) -> None:
         """Attach the stable context proxy to instance as ``_fun_watch``."""
         if getattr(instance, "_fun_watch", None) is not self._context_proxy:
             instance._fun_watch = self._context_proxy
+
+    def get_or_create_aggregate_context(
+        self,
+        function_hash: str,
+        runtime_id: str,
+        *,
+        main_app: str,
+        app_id: str,
+        start_time: datetime,
+        log_role: str = "function",
+        caller_log_id: int | None = None,
+    ) -> FunWatchContext:
+        """Return the aggregate context for (function_hash, runtime_id), creating one on first call.
+
+        Uses double-checked locking: fast-path read without lock, then atomic
+        creation under ``_aggregate_lock`` on first access.  The FunctionLog
+        INSERT happens inside the lock to guarantee exactly one row per function
+        per runtime.
+        """
+        key = (function_hash, runtime_id)
+        context = self._aggregate_contexts.get(key)
+        if context is not None:
+            return context
+
+        with self._aggregate_lock:
+            context = self._aggregate_contexts.get(key)
+            if context is not None:
+                return context
+
+            context = FunWatchContext()
+            context.first_start_time = start_time
+            context.log_id = self.start_function_log(
+                function_hash=function_hash,
+                main_app=main_app,
+                app_id=app_id,
+                start_time=start_time,
+                runtime_id=runtime_id,
+                log_role=log_role,
+                caller_log_id=caller_log_id,
+            )
+            self._aggregate_contexts[key] = context
+            return context
 
     def register_function(
         self,
@@ -385,12 +464,54 @@ class FunWatchRegistry:
             except Exception:
                 logger.exception("Failed to register function", function_name=function_name)
 
+    def register_thread(
+        self,
+        callback: Callable[..., Any],
+        app_id: str,
+        runtime_id: str,
+        *,
+        main_app: str | None = None,
+        caller_log_id: int | None = None,
+    ) -> tuple[FunWatchContext, str]:
+        """Register a thread pool callback in AppFunctions and create its aggregate FunctionLog.
+
+        Used by ``process_batch()`` to make thread callbacks visible in
+        AppFunctions and FunctionLog with ``log_role='thread'``.
+
+        Args:
+            callback: The worker callable (e.g. ``self._scrape_page``).
+            app_id: Application hash identifier.
+            runtime_id: Current runtime hash.
+            main_app: Root app hash (defaults to app_id).
+            caller_log_id: FunctionLog id of the caller (for thread-to-caller navigability).
+
+        Returns:
+            Tuple of (aggregate FunWatchContext, function_hash for structlog binding).
+        """
+        function_name = getattr(callback, "__qualname__", None) or getattr(callback, "__name__", "thread_callback")
+        function_hash = str(make_hash(app_id + function_name))
+        filepath = inspect.getfile(callback) if hasattr(callback, "__code__") else ""
+
+        self.register_function(function_hash, function_name, filepath, app_id)
+
+        context = self.get_or_create_aggregate_context(
+            function_hash,
+            runtime_id,
+            main_app=main_app or app_id,
+            app_id=app_id,
+            start_time=datetime.now(UTC),
+            log_role="thread",
+            caller_log_id=caller_log_id,
+        )
+        return context, function_hash
+
     def update_last_seen(self, function_hash: str) -> None:
         """Touch AppFunctions.last_seen for the given hash."""
         db = self._get_system_db()
         try:
             with db.create_session() as session:
-                stmt = select(AppFunctions).where(AppFunctions.function_hash == function_hash)
+                from sqlalchemy import select as sa_select
+                stmt = sa_select(AppFunctions).where(AppFunctions.function_hash == function_hash)
                 record = db.query(stmt, session).scalar_one_or_none()
                 if record is not None:
                     record.last_seen = datetime.now(UTC)  # type: ignore[assignment]
@@ -402,32 +523,24 @@ class FunWatchRegistry:
         self,
         *,
         function_hash: str,
-        execution_order: int,
-        thread_execution_order: int,
         main_app: str,
         app_id: str,
-        thread_id: int,
-        task_size: int | None,
         start_time: datetime,
         runtime_id: str,
-        parent_log_id: int | None,
         log_role: str,
+        caller_log_id: int | None = None,
     ) -> int | None:
-        """INSERT a partial FunctionLog row and return its auto-generated id."""
+        """INSERT a FunctionLog row for a new (function_hash, runtime) aggregate."""
         db = self._get_system_db()
         try:
             record = FunctionLog(
                 function_hash=function_hash,
-                execution_order=execution_order,
-                thread_execution_order=thread_execution_order,
                 main_app=main_app,
                 app_id=app_id,
-                thread_id=thread_id,
-                task_size=task_size,
                 start_time=start_time,
                 runtime=runtime_id,
-                parent_log_id=parent_log_id,
                 log_role=log_role,
+                caller_log_id=caller_log_id,
             )
             with db.create_session() as session:
                 db.add(record, session, flush=True)
@@ -444,17 +557,17 @@ class FunWatchRegistry:
         log_id: int | None,
         solved: int,
         failed: int,
-        start_time: datetime,
+        call_count: int,
         end_time: datetime,
+        total_elapsed_ms: int,
+        average_elapsed_ms: int,
+        median_elapsed_ms: int,
+        min_elapsed_ms: int,
+        max_elapsed_ms: int,
         exc_occurred: bool = False,
-        error_type: str | None = None,
-        error_message: str | None = None,
-        item_error_count: int = 0,
-        item_error_types_json: str | None = None,
-        item_error_samples_json: str | None = None,
         task_size: int | None = None,
     ) -> None:
-        """UPDATE an existing FunctionLog row with final metrics and error details."""
+        """UPDATE an existing FunctionLog row with aggregate metrics."""
         if log_id is None:
             return
         db = self._get_system_db()
@@ -464,69 +577,28 @@ class FunWatchRegistry:
                 if record is not None:
                     record.solved = solved  # type: ignore[assignment]
                     record.failed = failed  # type: ignore[assignment]
+                    record.call_count = call_count  # type: ignore[assignment]
                     record.processed_count = solved + failed  # type: ignore[assignment]
                     record.is_success = not exc_occurred and failed == 0  # type: ignore[assignment]
                     record.end_time = end_time  # type: ignore[assignment]
-                    record.totals = get_totals(start_time, end_time)  # type: ignore[assignment]
-                    record.totalm = get_totalm(start_time, end_time)  # type: ignore[assignment]
-                    record.totalh = get_totalh(start_time, end_time)  # type: ignore[assignment]
+                    record.total_elapsed_ms = total_elapsed_ms  # type: ignore[assignment]
+                    record.average_elapsed_ms = average_elapsed_ms  # type: ignore[assignment]
+                    record.median_elapsed_ms = median_elapsed_ms  # type: ignore[assignment]
+                    record.min_elapsed_ms = min_elapsed_ms  # type: ignore[assignment]
+                    record.max_elapsed_ms = max_elapsed_ms  # type: ignore[assignment]
                     if task_size is not None:
                         record.task_size = task_size  # type: ignore[assignment]
-                    if error_type is not None or item_error_count > 0:
-                        # When no Python exception was caught but item-level errors
-                        # were tracked via mark_failed(), derive the top-level
-                        # error_type and error_message from the dominant error type.
-                        effective_error_type = error_type
-                        effective_error_message = error_message
-                        if effective_error_type is None and item_error_types_json:
-                            try:
-                                error_types: dict[str, int] = json.loads(item_error_types_json)
-                                if error_types:
-                                    dominant_type = max(error_types, key=lambda key: error_types[key])
-                                    effective_error_type = dominant_type
-                                    if effective_error_message is None and item_error_samples_json:
-                                        samples: dict[str, list[str]] = json.loads(item_error_samples_json)
-                                        dominant_samples = samples.get(dominant_type, [])
-                                        if dominant_samples:
-                                            effective_error_message = dominant_samples[0]
-                            except (json.JSONDecodeError, TypeError, KeyError):
-                                pass
-                        error_record = FunctionLogError(
-                            function_log_id=log_id,
-                            error_type=effective_error_type,
-                            error_message=effective_error_message,
-                            item_error_count=item_error_count,
-                            item_error_types_json=item_error_types_json,
-                            item_error_samples_json=item_error_samples_json,
-                        )
-                        db.add(error_record, session)
                     session.commit()
         except Exception:
             logger.exception("Failed to complete FunctionLog", log_id=log_id)
 
-    def update_parent_log_role(self, log_id: int | None) -> None:
-        """Update a FunctionLog row's log_role to 'parent'."""
-        if log_id is None:
-            return
-        db = self._get_system_db()
-        try:
-            with db.create_session() as session:
-                record = session.get(FunctionLog, log_id)
-                if record is not None and str(record.log_role) != "parent":
-                    record.log_role = "parent"  # type: ignore[assignment]
-                    session.commit()
-        except Exception:
-            logger.exception("Failed to update parent log_role", log_id=log_id)
-
 
 def _finalize_fun_watch(
     *,
-    invocation_context: FunWatchContext,
+    aggregate_context: FunWatchContext,
     registry: FunWatchRegistry,
-    start_time: datetime,
+    invocation_start_time: datetime,
     exc_occurred: bool,
-    caught_error_type: str | None,
-    caught_error_message: str | None,
     log_lifecycle: bool,
     effective_log_level: int,
     app_logger: Any,
@@ -541,32 +613,36 @@ def _finalize_fun_watch(
     prev_function_id: Any,
     prev_call_chain: Any,
     prev_thread_id: Any,
+    prev_function_name: Any,
     context_token: Token[FunWatchContext | None],
 ) -> None:
     """Shared finalization logic for sync and async @fun_watch wrappers."""
     try:
-        solved, failed = invocation_context.snapshot()
-        item_error_count, item_error_types_json, item_error_samples_json = (
-            invocation_context.error_snapshot()
-        )
         end_time = datetime.now(UTC)
-        duration_s = (end_time - start_time).total_seconds()
+        duration_ms = (end_time - invocation_start_time).total_seconds() * 1000.0
+        aggregate_context.record_invocation_duration(duration_ms)
+
+        solved, failed = aggregate_context.snapshot()
+        total_elapsed_ms, average_elapsed_ms, median_elapsed_ms, min_elapsed_ms, max_elapsed_ms = (
+            aggregate_context.timing_snapshot()
+        )
         registry.complete_function_log(
-            log_id=invocation_context.log_id,
+            log_id=aggregate_context.log_id,
             solved=solved,
             failed=failed,
-            start_time=start_time,
+            call_count=aggregate_context.call_count,
             end_time=end_time,
+            total_elapsed_ms=total_elapsed_ms,
+            average_elapsed_ms=average_elapsed_ms,
+            median_elapsed_ms=median_elapsed_ms,
+            min_elapsed_ms=min_elapsed_ms,
+            max_elapsed_ms=max_elapsed_ms,
             exc_occurred=exc_occurred,
-            error_type=caught_error_type,
-            error_message=caught_error_message,
-            item_error_count=item_error_count,
-            item_error_types_json=item_error_types_json,
-            item_error_samples_json=item_error_samples_json,
-            task_size=invocation_context.task_size,
+            task_size=aggregate_context.task_size,
         )
         registry.update_last_seen(function_id)
         if not exc_occurred and log_lifecycle:
+            duration_s = duration_ms / 1000.0
             app_logger.log(
                 effective_log_level,
                 "Function completed",
@@ -578,9 +654,10 @@ def _finalize_fun_watch(
                 failed=failed,
                 processed_count=solved + failed,
                 is_success=failed == 0,
-                task_size=invocation_context.task_size,
+                task_size=aggregate_context.task_size,
+                call_count=aggregate_context.call_count,
                 duration_s=duration_s,
-                log_id=invocation_context.log_id,
+                log_id=aggregate_context.log_id,
                 module_name=caller_module_name,
                 module_path=filepath,
                 lineno=func_lineno,
@@ -599,6 +676,10 @@ def _finalize_fun_watch(
             structlog.contextvars.bind_contextvars(thread_id=prev_thread_id)
         else:
             structlog.contextvars.unbind_contextvars("thread_id")
+        if prev_function_name is not None:
+            structlog.contextvars.bind_contextvars(function_name=prev_function_name)
+        else:
+            structlog.contextvars.unbind_contextvars("function_name")
         registry.unbind_context(context_token)
 
 
@@ -607,9 +688,9 @@ class _FunWatchSetupResult:
     """Holds all computed state from the shared setup phase of @fun_watch."""
 
     registry: FunWatchRegistry
-    invocation_context: FunWatchContext
+    aggregate_context: FunWatchContext
     context_token: Token[FunWatchContext | None]
-    start_time: datetime
+    invocation_start_time: datetime
     function_name: str = ""
     function_id: str = ""
     app_id: str = ""
@@ -623,6 +704,7 @@ class _FunWatchSetupResult:
     prev_function_id: Any = None
     prev_call_chain: Any = None
     prev_thread_id: Any = None
+    prev_function_name: Any = None
 
 
 def _setup_fun_watch_invocation(
@@ -636,9 +718,9 @@ def _setup_fun_watch_invocation(
 ) -> _FunWatchSetupResult:
     """Shared setup logic for sync and async @fun_watch wrappers.
 
-    Performs function registration, context binding, structlog context
-    management, and lifecycle logging. Returns all state needed by the
-    caller to invoke the decorated function and finalize.
+    Performs function registration, aggregate context retrieval/creation,
+    structlog context management, and lifecycle logging.  Returns all state
+    needed by the caller to invoke the decorated function and finalize.
     """
     registry = FunWatchRegistry.instance()
 
@@ -681,18 +763,30 @@ def _setup_fun_watch_invocation(
     if task_size_detect and args and hasattr(args[0], "__len__"):
         detected_task_size = len(args[0])
 
-    invocation_context = FunWatchContext(task_size=detected_task_size)
     registry.ensure_context_proxy(instance)
 
-    parent_log_id = registry.get_parent_log_id()
-    log_role = "child" if parent_log_id is not None else "single"
+    thread_id = threading.get_ident()
+    invocation_start_time = datetime.now(UTC)
 
-    context_token = registry.bind_context(invocation_context)
+    aggregate_context = registry.get_or_create_aggregate_context(
+        function_id,
+        runtime_id,
+        main_app=main_app,
+        app_id=app_id,
+        start_time=invocation_start_time,
+    )
+    aggregate_context.increment_call_count()
+
+    if detected_task_size is not None:
+        aggregate_context.task_size = detected_task_size
+
+    context_token = registry.bind_context(aggregate_context)
 
     previous_structlog_context = structlog.contextvars.get_contextvars()
     prev_function_id = previous_structlog_context.get("function_id")
     prev_call_chain = previous_structlog_context.get("call_chain")
     prev_thread_id = previous_structlog_context.get("thread_id")
+    prev_function_name = previous_structlog_context.get("function_name")
     if prev_call_chain:
         current_call_chain = f"{prev_call_chain} -> {chain_label}"
     else:
@@ -701,28 +795,10 @@ def _setup_fun_watch_invocation(
             current_call_chain = f"{root_caller} -> {chain_label}"
         else:
             current_call_chain = chain_label
-    thread_id = threading.get_ident()
     structlog.contextvars.bind_contextvars(
         function_id=function_id, call_chain=current_call_chain, thread_id=thread_id,
+        function_name=chain_label,
     )
-    execution_order, thread_execution_order = registry.next_execution_order(runtime_id, thread_id)
-    start_time = datetime.now(UTC)
-
-    invocation_context.log_id = registry.start_function_log(
-        function_hash=function_id,
-        execution_order=execution_order,
-        thread_execution_order=thread_execution_order,
-        main_app=main_app,
-        app_id=app_id,
-        thread_id=thread_id,
-        task_size=invocation_context.task_size,
-        start_time=start_time,
-        runtime_id=runtime_id,
-        parent_log_id=parent_log_id,
-        log_role=log_role,
-    )
-    if parent_log_id is not None:
-        registry.update_parent_log_role(parent_log_id)
 
     effective_log_level = log_level if log_level is not None else registry.default_lifecycle_log_level
     app_logger: Any = getattr(instance, "logger", logger)
@@ -737,9 +813,9 @@ def _setup_fun_watch_invocation(
             function_id=function_id,
             app_id=app_id,
             runtime=runtime_id,
-            log_id=invocation_context.log_id,
-            execution_order=execution_order,
-            log_role=log_role,
+            log_id=aggregate_context.log_id,
+            call_count=aggregate_context.call_count,
+            log_role="function",
             module_name=caller_module_name,
             module_path=filepath,
             lineno=func_lineno,
@@ -749,9 +825,9 @@ def _setup_fun_watch_invocation(
 
     return _FunWatchSetupResult(
         registry=registry,
-        invocation_context=invocation_context,
+        aggregate_context=aggregate_context,
         context_token=context_token,
-        start_time=start_time,
+        invocation_start_time=invocation_start_time,
         function_name=function_name,
         function_id=function_id,
         app_id=app_id,
@@ -765,6 +841,7 @@ def _setup_fun_watch_invocation(
         prev_function_id=prev_function_id,
         prev_call_chain=prev_call_chain,
         prev_thread_id=prev_thread_id,
+        prev_function_name=prev_function_name,
     )
 
 
@@ -775,7 +852,7 @@ def fun_watch(
     log_lifecycle: bool = True,
     log_level: int | None = None,
 ) -> Any:
-    """Decorator that monitors function execution and records metrics to DB.
+    """Decorator that monitors function execution and records aggregate metrics to DB.
 
     Supports both bare ``@fun_watch`` and parameterized ``@fun_watch(...)`` usage.
 
@@ -808,27 +885,23 @@ def fun_watch(
             )
 
             exc_occurred = False
-            caught_error_type: str | None = None
-            caught_error_message: str | None = None
             try:
                 result = decorated_func(self, *args, **kwargs)
             except Exception as exc:
                 exc_occurred = True
-                caught_error_type = type(exc).__name__
-                caught_error_message = str(exc)
-                _solved, _failed = setup.invocation_context.snapshot()
+                _solved, _failed = setup.aggregate_context.snapshot()
                 setup.app_logger.exception(
                     "Unhandled exception in @fun_watch decorated function",
                     function_name=setup.function_name,
                     function_id=setup.function_id,
                     app_id=setup.app_id,
                     runtime=setup.runtime_id,
-                    error_type=caught_error_type,
-                    error_message=caught_error_message,
+                    error_type=type(exc).__name__,
+                    error_message=str(exc),
                     solved=_solved,
                     failed=_failed,
                     is_success=False,
-                    log_id=setup.invocation_context.log_id,
+                    log_id=setup.aggregate_context.log_id,
                     module_name=setup.caller_module_name,
                     module_path=setup.filepath,
                     lineno=setup.func_lineno,
@@ -837,12 +910,10 @@ def fun_watch(
                 raise
             finally:
                 _finalize_fun_watch(
-                    invocation_context=setup.invocation_context,
+                    aggregate_context=setup.aggregate_context,
                     registry=setup.registry,
-                    start_time=setup.start_time,
+                    invocation_start_time=setup.invocation_start_time,
                     exc_occurred=exc_occurred,
-                    caught_error_type=caught_error_type,
-                    caught_error_message=caught_error_message,
                     log_lifecycle=log_lifecycle,
                     effective_log_level=setup.effective_log_level,
                     app_logger=setup.app_logger,
@@ -857,6 +928,7 @@ def fun_watch(
                     prev_function_id=setup.prev_function_id,
                     prev_call_chain=setup.prev_call_chain,
                     prev_thread_id=setup.prev_thread_id,
+                    prev_function_name=setup.prev_function_name,
                     context_token=setup.context_token,
                 )
 
@@ -870,27 +942,23 @@ def fun_watch(
             )
 
             exc_occurred = False
-            caught_error_type: str | None = None
-            caught_error_message: str | None = None
             try:
                 result = await decorated_func(self, *args, **kwargs)
             except Exception as exc:
                 exc_occurred = True
-                caught_error_type = type(exc).__name__
-                caught_error_message = str(exc)
-                _solved, _failed = setup.invocation_context.snapshot()
+                _solved, _failed = setup.aggregate_context.snapshot()
                 setup.app_logger.exception(
                     "Unhandled exception in @fun_watch decorated function",
                     function_name=setup.function_name,
                     function_id=setup.function_id,
                     app_id=setup.app_id,
                     runtime=setup.runtime_id,
-                    error_type=caught_error_type,
-                    error_message=caught_error_message,
+                    error_type=type(exc).__name__,
+                    error_message=str(exc),
                     solved=_solved,
                     failed=_failed,
                     is_success=False,
-                    log_id=setup.invocation_context.log_id,
+                    log_id=setup.aggregate_context.log_id,
                     module_name=setup.caller_module_name,
                     module_path=setup.filepath,
                     lineno=setup.func_lineno,
@@ -899,12 +967,10 @@ def fun_watch(
                 raise
             finally:
                 _finalize_fun_watch(
-                    invocation_context=setup.invocation_context,
+                    aggregate_context=setup.aggregate_context,
                     registry=setup.registry,
-                    start_time=setup.start_time,
+                    invocation_start_time=setup.invocation_start_time,
                     exc_occurred=exc_occurred,
-                    caught_error_type=caught_error_type,
-                    caught_error_message=caught_error_message,
                     log_lifecycle=log_lifecycle,
                     effective_log_level=setup.effective_log_level,
                     app_logger=setup.app_logger,
@@ -919,6 +985,7 @@ def fun_watch(
                     prev_function_id=setup.prev_function_id,
                     prev_call_chain=setup.prev_call_chain,
                     prev_thread_id=setup.prev_thread_id,
+                    prev_function_name=setup.prev_function_name,
                     context_token=setup.context_token,
                 )
 

--- a/docs/1.2. data-model.md
+++ b/docs/1.2. data-model.md
@@ -117,31 +117,18 @@ See [1.3. Enums](1.3.%20enums.md) for complete definitions, usage patterns, and 
           │                         │ + std cols │  │ function_log        │
           │                         └────────────┘  │─────────────────────│
           │                                         │ function_hash───────│─FK
-          │                                         │ execution_order     │
+          │                                         │ log_role            │
           │                                         │ main_app            │
           │                                         │ app_id              │
           │                                         │ runtime ────────────│─FK
-          │                                         │ thread_id           │
-          │                                         │ log_role            │
-          │                                         │ parent_log_id       │
+          │                                         │ call_count          │
           │                                         │ task_size           │
           │                                         │ solved/failed       │
           │                                         │ processed_count     │
           │                                         │ is_success          │
           │                                         │ start_time/end_time │
-          │                                         │ totals/m/h          │
-          │                                         │ + std cols          │
-          │                                         └──────┬──────────────┘
-          │                                                │ 1:0..1
-          │                                         ┌──────┴──────────────┐
-          │                                         │ function_log_error  │
-          │                                         │─────────────────────│
-          │                                         │ function_log_id ────│─FK (CASCADE)
-          │                                         │ error_type          │
-          │                                         │ error_message       │
-          │                                         │ item_error_count    │
-          │                                         │ item_error_types    │
-          │                                         │ item_error_samples  │
+          │                                         │ timing metrics (ms) │
+          │                                         │ caller_log_id       │
           │                                         │ + std cols          │
           │                                         └─────────────────────┘
     ┌─────┴────────────┐           └────────────┘
@@ -319,28 +306,35 @@ Function registry populated automatically by `@fun_watch` on first invocation. P
 
 ### FunctionLog
 
-Per-function execution timing, populated by the `@fun_watch` decorator. Answers "which function ran, how long did it take, and how much data did it process?" within a runtime cycle.
+Per-function-per-runtime aggregate execution metrics, populated by the `@fun_watch` decorator. One row per function per runtime. Answers "how did each function perform across this runtime?" with accumulated counters and per-invocation timing statistics.
 
 | Column | Type | Constraints | Description |
 |--------|------|-------------|-------------|
 | `id` | BigInteger | PK, auto-increment | Row identifier |
 | `function_hash` | String(64) | FK → `app_functions.function_hash`, INDEX | Links to function registry |
-| `execution_order` | Integer | | Execution order within the app (per-thread) |
+| `log_role` | String(16) | default: `'function'` | `'function'` for decorated methods, `'thread'` for thread pool callbacks |
 | `main_app` | String(64) | INDEX | Hash of the root app |
 | `app_id` | String(64) | INDEX | Hash of app_group + app_parent + app_name |
-| `thread_id` | BigInteger | | Thread ID running this function instance |
+| `call_count` | BigInteger | default: 1 | Number of invocations in this runtime |
 | `task_size` | BigInteger | | Size of list/dataset given to the function |
-| `solved` | Integer | default: 0 | Successfully processed items |
-| `failed` | Integer | default: 0 | Items that ended with error |
-| `start_time` | DateTime | | When function execution started |
-| `end_time` | DateTime | | When function execution ended |
-| `totals` | Integer | | Function runtime in seconds |
-| `totalm` | Integer | | Function runtime in minutes |
-| `totalh` | Integer | | Function runtime in hours |
+| `solved` | Integer | default: 0 | Accumulated successfully processed items |
+| `failed` | Integer | default: 0 | Accumulated items that ended with error |
+| `processed_count` | BigInteger | default: 0 | Total processed items (solved + failed) |
+| `is_success` | Boolean | default: true | `false` when exception occurred or `failed > 0` |
+| `start_time` | DateTime | | When the first invocation began |
+| `end_time` | DateTime | | When the last invocation completed |
+| `total_elapsed_ms` | BigInteger | | Sum of all invocation durations in milliseconds |
+| `average_elapsed_ms` | Integer | | Mean invocation duration in milliseconds |
+| `median_elapsed_ms` | Integer | | P50 invocation duration in milliseconds |
+| `min_elapsed_ms` | Integer | | Fastest invocation in milliseconds |
+| `max_elapsed_ms` | Integer | | Slowest invocation in milliseconds |
+| `caller_log_id` | BigInteger | | Self-referential FK to the caller's FunctionLog id. Set on `log_role='thread'` rows only |
 | `runtime` | String(64) | FK → `runtime.runtime`, INDEX | Links to execution cycle |
-| + standard columns | | | sha, archive, date_created, date_modified |
+| `date_created` | DateTime | server_default: now() | Row creation timestamp |
 
-**Use case:** Production performance monitoring. Apps table shows live dashboard (current loop only). FunctionLog preserves the historical record — every loop from every runtime with task_size, solved, and failed counts. When an app's runtime increases, query FunctionLog to identify which function is the bottleneck and whether failures are increasing. Function metadata (name, filepath) is stored once in `app_functions`, not repeated per log row. For line-level profiling, developers use `cProfile` or `line_profiler` locally.
+**Unique constraint:** `(function_hash, runtime)` -- enforces one aggregate row per function per runtime.
+
+**Use case:** Production performance monitoring. Apps table shows live dashboard (current loop only). FunctionLog preserves the historical record — every runtime with task_size, solved, failed counts, and per-invocation timing statistics. When an app's runtime increases, query FunctionLog to identify which function is the bottleneck (highest `median_elapsed_ms`) and whether failures are increasing. Function metadata (name, filepath) is stored once in `app_functions`, not repeated per log row. Error details (tracebacks, exception messages) live in the `Logs` table, joinable via `FunctionLog.function_hash = Logs.function_id`.
 
 ## Command Tracking
 

--- a/docs/12. captcha.md
+++ b/docs/12. captcha.md
@@ -244,7 +244,7 @@ Logging is optional. Pass `database`, `app_id`, and `runtime` to the provider co
 
 ## CaptchaLogError Table
 
-Provider error details for failed captcha solve attempts. One-to-one with CaptchaLog, following the FunctionLog/FunctionLogError split pattern (`data_collector/tables/log.py`). A row is created only when the provider returns an error (status FAILED or TIMED_OUT). Successful solves have no error record.
+Provider error details for failed captcha solve attempts. One-to-one with CaptchaLog, following the CaptchaLog/CaptchaLogError split pattern (`data_collector/tables/captcha.py`). A row is created only when the provider returns an error (status FAILED or TIMED_OUT). Successful solves have no error record.
 
 | Column | Type | Notes |
 |--------|------|-------|

--- a/docs/25. fun-watch.md
+++ b/docs/25. fun-watch.md
@@ -37,41 +37,56 @@ Function registry populated automatically by `@fun_watch` on first invocation. S
 
 ## FunctionLog Table
 
-Stores one row per decorated function invocation. Function metadata (name, filepath) lives in `AppFunctions`, not repeated here. See [1.2. data-model.md](1.2.%20data-model.md#functionlog) for full column definitions.
+Stores one aggregate row per decorated function per runtime. All invocations of the same function within a runtime accumulate into a single row. Function metadata (name, filepath) lives in `AppFunctions`, not repeated here. See [1.2. data-model.md](1.2.%20data-model.md#functionlog) for full column definitions.
 
 | Column | Type | Description |
 |--------|------|-------------|
 | `id` | BigInteger (PK) | Auto-increment row identifier |
 | `function_hash` | String(64) (FK) | References `app_functions.function_hash` |
-| `execution_order` | Integer | Execution order within the app (per-thread) |
+| `log_role` | String(16) | `'function'` for decorated methods, `'thread'` for thread pool callbacks |
 | `main_app` | String(64) | Hash of the root app |
 | `app_id` | String(64) | Hash of app_group + app_parent + app_name |
-| `thread_id` | BigInteger | Thread ID running this function instance |
+| `call_count` | BigInteger | Number of times this function was invoked in this runtime |
 | `task_size` | BigInteger | Number of items to process (input size) |
-| `solved` | Integer | Number of items successfully processed (default: 0) |
-| `failed` | Integer | Number of items that failed processing (default: 0) |
+| `solved` | Integer | Accumulated successfully processed items (default: 0) |
+| `failed` | Integer | Accumulated failed items (default: 0) |
 | `processed_count` | BigInteger | Total processed items (`solved + failed`, default: 0) |
 | `is_success` | Boolean | `false` when an exception occurred or `failed > 0` (default: true) |
-| `start_time` | DateTime | When the function began executing |
-| `end_time` | DateTime | When the function finished executing |
-| `totals` | Integer | Total execution time in seconds |
-| `totalm` | Integer | Execution time in minutes |
-| `totalh` | Integer | Execution time in hours |
+| `start_time` | DateTime | When the first invocation began |
+| `end_time` | DateTime | When the last invocation completed |
+| `total_elapsed_ms` | BigInteger | Sum of all invocation durations in milliseconds |
+| `average_elapsed_ms` | Integer | Mean invocation duration in milliseconds |
+| `median_elapsed_ms` | Integer | P50 invocation duration in milliseconds |
+| `min_elapsed_ms` | Integer | Fastest invocation duration in milliseconds |
+| `max_elapsed_ms` | Integer | Slowest invocation duration in milliseconds |
+| `caller_log_id` | BigInteger | Self-referential FK to the caller's FunctionLog id. Set on `log_role='thread'` rows only |
 | `runtime` | String(64) (FK) | Foreign key to Runtime table |
 
-## FunctionLogError Table
+**Unique constraint:** `(function_hash, runtime)` -- enforces one aggregate row per function per runtime.
 
-Stores error details for failed invocations. Only created when an exception occurs or `mark_failed(error_type=...)` is called. Successful invocations have no row in this table. Cascade-deleted when the parent FunctionLog row is removed.
+## Error Handling
 
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | BigInteger (PK) | Auto-increment row identifier |
-| `function_log_id` | BigInteger (FK, unique) | References `function_log.id` with `ON DELETE CASCADE` |
-| `error_type` | String(256) | Exception class name (e.g. `"RuntimeError"`) |
-| `error_message` | Text | Exception message string |
-| `item_error_count` | Integer | Count of items with typed errors via `mark_failed(error_type=...)` (default: 0) |
-| `item_error_types_json` | Text | JSON: error type to count mapping, e.g. `{"ValueError": 3}` |
-| `item_error_samples_json` | Text | JSON: error type to sample messages (max 5 per type) |
+Errors are recorded in the `Logs` table, not in a separate error table. The join path `FunctionLog.function_hash = Logs.function_id` connects function metrics to error details.
+
+**Handled exceptions (app catches):** The application calls `self.logger.exception(...)` or `self.logger.error(...)` at the call site, then `self.increment_failed()` for the counter. The Logs record has the correct `module_name`, `lineno`, and traceback from the app code.
+
+**Unhandled exceptions (framework catches):** When an exception propagates out of a thread callback, `wrap_with_thread_context` catches it, logs via the app logger with traceback and the raise-site `module_name`/`lineno`, then re-raises. The counter is recorded on the thread context.
+
+**Unhandled exceptions in decorated functions:** The `@fun_watch` decorator catches unhandled exceptions, logs via `app_logger.exception()` with full traceback, then re-raises. The `FunctionLog.is_success` is set to `false`.
+
+```sql
+-- Find error details for a specific function in a runtime
+SELECT l.msg, l.module_name, l.lineno, l.context_json
+FROM logs l
+JOIN function_log fl ON fl.function_hash = l.function_id AND fl.runtime = l.runtime
+WHERE fl.id = 3 AND l.log_level >= 40;
+
+-- Find errors from thread callbacks via caller navigability
+SELECT l.msg, l.call_chain, l.context_json
+FROM logs l
+JOIN function_log fl ON fl.function_hash = l.function_id AND fl.runtime = l.runtime
+WHERE fl.caller_log_id = 2 AND l.log_level >= 40;
+```
 
 ## How It Works
 
@@ -96,9 +111,9 @@ When `@fun_watch` decorates a function, it:
 3. Emits "Function started" (DEBUG) via `self.logger` (or module-level fallback)
 4. Records `start_time` when the function begins
 5. Captures `task_size` from the function's input (configurable attribute)
-6. Tracks `solved` and `failed` counts during execution (per-invocation context)
-7. Records `end_time` and computes `totals`, `totalm`, `totalh` when the function completes
-8. Inserts a `FunctionLog` row linked to the current `runtime` and `function_hash`
+6. Tracks `solved` and `failed` counts during execution (shared aggregate context per function per runtime)
+7. Records `end_time` and computes per-invocation timing metrics when the function completes
+8. Upserts a `FunctionLog` row linked to the current `runtime` and `function_hash` (one row per function per runtime)
 9. Updates `app_functions.last_seen` timestamp
 10. Emits "Function completed" (DEBUG) on success with solved, failed, duration_s metrics
 11. On exception: emits "Unhandled exception" (ERROR) with traceback before re-raising
@@ -126,13 +141,13 @@ The decorator emits structured lifecycle log events through the application's lo
 |-------|-------|------|--------|
 | "Function started" | DEBUG | Before function execution | function_name, function_id, app_id, runtime, task_size, module_name, module_path, lineno, call_chain |
 | "Function completed" | DEBUG | After successful execution | function_name, function_id, app_id, runtime, solved, failed, processed_count, is_success, task_size, duration_s, module_name, module_path, lineno, call_chain |
-| "Unhandled exception" | ERROR | On unhandled exception (before re-raise) | function_name, function_id, app_id, runtime, error_type, error_message, solved, failed, is_success (always False), module_name, module_path, lineno, call_chain, traceback |
+| "Unhandled exception" | ERROR | On unhandled exception (before re-raise) | function_name, function_id, app_id, runtime, solved, failed, is_success (always False), module_name, module_path, lineno, call_chain, traceback (in context_json) |
 
-The `is_success`, `processed_count`, `error_type`, and `error_message` fields enable Splunk dashboards for error-rate alerting and spike detection without querying the database.
+The `is_success` and `processed_count` fields enable Splunk dashboards for error-rate alerting and spike detection without querying the database.
 
 **Log level:** Lifecycle events emit at DEBUG level. In production, set `log_level` to INFO to suppress start/end events while still capturing exceptions (ERROR). Lower to DEBUG for full function-level tracing during troubleshooting.
 
-**Relationship to FunctionLog:** `FunctionLog` stores structured metrics (one row per invocation, queryable by function/runtime/date). Lifecycle logs store operational events in the `Logs` table with full structlog context, traceback, and call chain. Both tables are written on every invocation — they serve different monitoring needs.
+**Relationship to FunctionLog and Logs:** `FunctionLog` stores aggregate metrics (one row per function per runtime). Error details (tracebacks, exception messages) live in the `Logs` table, joinable via `FunctionLog.function_hash = Logs.function_id`. Both tables are written on every invocation — they serve different monitoring needs.
 
 ## Thread Safety
 
@@ -152,7 +167,7 @@ def fun_watch(func):
         # Bind per-invocation context in context-local state
         # self._fun_watch is a stable proxy to that active context
         # ... execute func ...
-        # INSERT into FunctionLog with thread_id = threading.get_ident()
+        # INSERT/UPDATE FunctionLog aggregate row
     return wrapper
 ```
 
@@ -181,13 +196,35 @@ raises `RuntimeError`.
 When using fan-out workers, wait for all wrapped futures/threads to complete before the decorated method returns.
 Otherwise late worker updates may be missing from the `FunctionLog` row written in the decorator `finally` block.
 
-### Per-Thread FunctionLog Rows
+### Aggregate FunctionLog Model
 
-Each thread writes its own `FunctionLog` row with `thread_id` set to `threading.get_ident()`. The `execution_order` ordinal is assigned per-thread within a runtime — thread A gets its own sequence, thread B gets its own.
+All invocations of the same `@fun_watch`-decorated function within a single runtime share one aggregate `FunctionLog` row. The `call_count` column tracks how many times the function was invoked. Per-invocation timing is collected in memory and written as aggregate statistics (`total_elapsed_ms`, `average_elapsed_ms`, `median_elapsed_ms`, `min_elapsed_ms`, `max_elapsed_ms`).
+
+Thread pool callbacks registered via `process_batch()` get their own `FunctionLog` row with `log_role='thread'` and are auto-registered in `AppFunctions`. The thread row's `caller_log_id` points to the caller's (e.g. `collect()`) FunctionLog id for navigability.
+
+Workers bound via `wrap_with_thread_context` have `function_id` and `function_name` overridden in structlog contextvars to the thread's function hash and qualified name. This ensures all log records emitted from within workers (including error logs) point to the correct FunctionLog row via `Logs.function_id = FunctionLog.function_hash`.
+
+### Timing Semantics
+
+FunctionLog timing columns measure **cumulative invocation time**, not wall-clock span:
+
+- **`total_elapsed_ms`**: Sum of all individual invocation durations across `call_count` calls. For `log_role='function'` called once (e.g. `collect()`), this equals the wall-clock time of the entire call including internal thread/async work.
+- **`log_role='thread'` timing**: Sum of all parallel callback durations. Since callbacks run concurrently, this value is typically **larger** than the caller's wall-clock time. Example: 10 callbacks averaging 1.8s on 3 threads = ~18s cumulative, but ~6.8s wall-clock on the caller.
+- **`average_elapsed_ms`**: Mean duration per invocation -- directly comparable across log roles regardless of parallelism.
+- **Wall-clock span**: Always derivable from `end_time - start_time` on any row.
+
+### Counter Propagation
+
+When `process_batch()` or `process_batch_async()` runs thread callbacks, the `solved` and `failed` counters are recorded on both rows:
+
+- The **thread row** (`log_role='thread'`) accumulates counters from `increment_solved()` / `increment_failed()` calls within worker callbacks.
+- The **caller row** (`log_role='function'`, e.g. `collect()`) receives the same totals via counter propagation after all workers complete.
+
+Both rows show `task_size = len(items)` for the work list size.
 
 ### Apps Table Update
 
-Apps table live dashboard updates (current function name, progress) are a `BaseScraper` responsibility (WP-04), not `@fun_watch`. The decorator focuses exclusively on `FunctionLog` metrics and `AppFunctions` registration. Thread-level progress is available via `FunctionLog` queries filtered by `thread_id`.
+Apps table live dashboard updates (current function name, progress) are a `BaseScraper` responsibility (WP-04), not `@fun_watch`. The decorator focuses exclusively on `FunctionLog` metrics and `AppFunctions` registration.
 
 ## Production Performance Monitoring
 

--- a/docs/50. roadmap.md
+++ b/docs/50. roadmap.md
@@ -129,10 +129,9 @@ Function-level performance monitoring decorator.
 | Deliverable | Description |
 |-------------|-------------|
 | `AppFunctions` table | Registry with `function_hash` identity, auto-registration, caching |
-| `FunctionLog` table | Per-invocation metrics: elapsed time, row counts, error state |
-| `FunctionLogError` table | Error sample storage (max 5 per type), linked to FunctionLog |
+| `FunctionLog` table | Per-function-per-runtime aggregate metrics: timing, counters, error state. Errors flow to Logs table |
 | `FunWatchRegistry` singleton | Double-checked locking, ContextVar management, DB/registration locks |
-| `FunWatchContext` | Per-invocation context with `__slots__`, thread-safe counters, error sample collection |
+| `FunWatchContext` | Per-invocation context with `__slots__`, thread-safe counters |
 | `FunWatchMixin` | Type-safe `fun_watch_context` property for decorated classes |
 | `@fun_watch` decorator | Closure-local counters, per-thread FunctionLog rows, sync + async support, structlog context propagation |
 
@@ -259,7 +258,7 @@ The central orchestrator — schedules apps, dispatches commands, manages proces
 | `Scheduler` | `next_run` calculation: cron expression (croniter) and interval-based (minutes) with fallback scheduling |
 | `ProcessTracker` | `subprocess.Popen` with `sys.executable -m`, PID tracking, Windows/Unix alive checks (ctypes/os.kill), orphan cleanup |
 | `CommandHandler` | Unified thread-safe `queue.Queue` bridging DB polling (`cmd_flag=PENDING`) and RabbitMQ consumer, audit trail via `CommandLog` |
-| `RetentionCleaner` | FK-ordered periodic deletion of function_log_error, function_log, logs, runtime, command_log; app purge with directory cleanup |
+| `RetentionCleaner` | FK-ordered periodic deletion of function_log, logs, runtime, command_log; app purge with directory cleanup |
 | `CommandLog` table | Audit trail: app_id, cmd_by, cmd_name, cmd_time, cmd_flag, cmd_exec, date_created |
 | `ManagerSettings` | Pydantic BaseSettings with `DC_MANAGER_` prefix: polling intervals, failure thresholds, retention periods, integration toggles |
 | CLI entry point | `python -m data_collector.orchestration` with `--stop-apps` flag for independent process termination |

--- a/tests/integration/fun_watch/conftest.py
+++ b/tests/integration/fun_watch/conftest.py
@@ -19,7 +19,7 @@ from data_collector.tables.apps import (
     CodebookFatalFlags,
     CodebookRunStatus,
 )
-from data_collector.tables.log import FunctionLog, FunctionLogError
+from data_collector.tables.log import FunctionLog
 from data_collector.tables.runtime import Runtime
 from data_collector.utilities.database.main import Database
 from data_collector.utilities.fun_watch import FunWatchRegistry
@@ -63,7 +63,7 @@ def seed_fun_watch_parents(db: Database, db_engine: Engine) -> Generator[None]:
     yield
 
     with db.create_session() as session:
-        session.execute(delete(FunctionLogError))
+
         session.execute(delete(FunctionLog))
         session.execute(delete(AppFunctions))
         for app_kwargs in _TEST_APPS:
@@ -85,7 +85,6 @@ def reset_registry() -> None:  # noqa: PT004
 @pytest.fixture()
 def clean_fun_watch_tables(session: Session) -> None:
     """Delete all fun_watch-related rows before the test."""
-    session.execute(delete(FunctionLogError))
     session.execute(delete(FunctionLog))
     session.execute(delete(AppFunctions))
     session.commit()

--- a/tests/unit/fun_watch/test_context.py
+++ b/tests/unit/fun_watch/test_context.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import threading
 
 from data_collector.utilities.fun_watch import FunWatchContext
@@ -98,51 +97,75 @@ class TestFunWatchContext:
         assert completed.is_set()
         assert context.failed == 1
 
-    def test_mark_failed_backwards_compatible(self) -> None:
+    def test_mark_failed_simple(self) -> None:
         context = FunWatchContext()
         context.mark_failed(3)
         assert context.failed == 3
-        item_error_count, types_json, samples_json = context.error_snapshot()
-        assert item_error_count == 0
-        assert types_json is None
-        assert samples_json is None
 
-    def test_mark_failed_with_error_type_aggregates(self) -> None:
+    def test_call_count_initial(self) -> None:
         context = FunWatchContext()
-        context.mark_failed(2, error_type="ValueError", error_message="bad value")
-        context.mark_failed(3, error_type="KeyError", error_message="missing key")
-        context.mark_failed(1, error_type="ValueError", error_message="another bad value")
-        assert context.failed == 6
-        item_error_count, types_json, samples_json = context.error_snapshot()
-        assert item_error_count == 6
-        types = json.loads(str(types_json))
-        assert types == {"ValueError": 3, "KeyError": 3}
-        samples = json.loads(str(samples_json))
-        assert samples["ValueError"] == ["bad value", "another bad value"]
-        assert samples["KeyError"] == ["missing key"]
+        assert context.call_count == 0
 
-    def test_mark_failed_with_error_message_samples_capped(self) -> None:
+    def test_increment_call_count(self) -> None:
         context = FunWatchContext()
-        for i in range(10):
-            context.mark_failed(1, error_type="RuntimeError", error_message=f"msg_{i}")
-        item_error_count, _types_json, samples_json = context.error_snapshot()
-        assert item_error_count == 10
-        samples = json.loads(str(samples_json))
-        assert len(samples["RuntimeError"]) == 5
+        context.increment_call_count()
+        context.increment_call_count()
+        context.increment_call_count()
+        assert context.call_count == 3
 
-    def test_error_snapshot_empty_when_no_typed_errors(self) -> None:
+    def test_first_start_time_initial(self) -> None:
         context = FunWatchContext()
-        context.mark_failed(5)
-        item_error_count, types_json, samples_json = context.error_snapshot()
-        assert item_error_count == 0
-        assert types_json is None
-        assert samples_json is None
+        assert context.first_start_time is None
 
-    def test_mark_failed_error_type_without_message(self) -> None:
+    def test_invocation_durations_initial(self) -> None:
         context = FunWatchContext()
-        context.mark_failed(2, error_type="TimeoutError")
-        item_error_count, types_json, samples_json = context.error_snapshot()
-        assert item_error_count == 2
-        types = json.loads(str(types_json))
-        assert types == {"TimeoutError": 2}
-        assert samples_json is None
+        total, average, median, minimum, maximum = context.timing_snapshot()
+        assert total == 0
+        assert average == 0
+        assert median == 0
+        assert minimum == 0
+        assert maximum == 0
+
+    def test_record_invocation_duration(self) -> None:
+        context = FunWatchContext()
+        context.record_invocation_duration(100.0)
+        context.record_invocation_duration(200.0)
+        context.record_invocation_duration(300.0)
+        total, average, median, minimum, maximum = context.timing_snapshot()
+        assert total == 600
+        assert average == 200
+        assert median == 200
+        assert minimum == 100
+        assert maximum == 300
+
+    def test_timing_snapshot_single_duration(self) -> None:
+        context = FunWatchContext()
+        context.record_invocation_duration(150.0)
+        total, average, median, minimum, maximum = context.timing_snapshot()
+        assert total == 150
+        assert average == 150
+        assert median == 150
+        assert minimum == 150
+        assert maximum == 150
+
+    def test_timing_snapshot_thread_safety(self) -> None:
+        context = FunWatchContext()
+        barrier = threading.Barrier(4)
+
+        def worker() -> None:
+            barrier.wait()
+            for _ in range(100):
+                context.record_invocation_duration(10.0)
+
+        threads = [threading.Thread(target=worker) for _ in range(4)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(5.0)
+
+        total, average, median, minimum, maximum = context.timing_snapshot()
+        assert total == 4000
+        assert average == 10
+        assert median == 10
+        assert minimum == 10
+        assert maximum == 10

--- a/tests/unit/fun_watch/test_decorator.py
+++ b/tests/unit/fun_watch/test_decorator.py
@@ -139,7 +139,6 @@ class TestRegistration:
     def setup_method(self) -> None:
         FunWatchRegistry.reset()
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
@@ -150,7 +149,6 @@ class TestRegistration:
         _mock_last_seen: MagicMock,
         _mock_start_log: MagicMock,
         _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         app = FakeApp()
         app.process_items(["a", "b", "c"])
@@ -158,7 +156,6 @@ class TestRegistration:
         call_args = mock_register.call_args
         assert call_args[0][1] == "process_items"
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
@@ -169,7 +166,6 @@ class TestRegistration:
         _mock_last_seen: MagicMock,
         _mock_start_log: MagicMock,
         _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         app = FakeApp()
         app.process_items(["a"])
@@ -181,7 +177,6 @@ class TestFunctionLog:
     def setup_method(self) -> None:
         FunWatchRegistry.reset()
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
@@ -192,13 +187,11 @@ class TestFunctionLog:
         _mock_last_seen: MagicMock,
         mock_start_log: MagicMock,
         mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         app = FakeApp()
         app.process_items(["a", "b"])
         mock_start_log.assert_called_once()
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
@@ -207,34 +200,30 @@ class TestFunctionLog:
         self,
         _mock_register: MagicMock,
         _mock_last_seen: MagicMock,
-        mock_start_log: MagicMock,
+        _mock_start_log: MagicMock,
         mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         app = FakeApp()
         app.process_items(["a", "b", "c"])
         call_kwargs = mock_complete_log.call_args[1]
         assert call_kwargs["solved"] == 3
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
     @patch(f"{_REGISTRY}.register_function")
-    def test_records_task_size(
+    def test_records_task_size_in_complete(
         self,
         _mock_register: MagicMock,
         _mock_last_seen: MagicMock,
-        mock_start_log: MagicMock,
+        _mock_start_log: MagicMock,
         mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         app = FakeApp()
         app.process_items(["a", "b", "c"])
-        call_kwargs = mock_start_log.call_args[1]
+        call_kwargs = mock_complete_log.call_args[1]
         assert call_kwargs["task_size"] == 3
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
@@ -243,16 +232,14 @@ class TestFunctionLog:
         self,
         _mock_register: MagicMock,
         _mock_last_seen: MagicMock,
-        mock_start_log: MagicMock,
+        _mock_start_log: MagicMock,
         mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         app = FakeApp()
         app.non_sized_arg(42)
-        call_kwargs = mock_start_log.call_args[1]
+        call_kwargs = mock_complete_log.call_args[1]
         assert call_kwargs["task_size"] is None
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
@@ -261,16 +248,14 @@ class TestFunctionLog:
         self,
         _mock_register: MagicMock,
         _mock_last_seen: MagicMock,
-        mock_start_log: MagicMock,
+        _mock_start_log: MagicMock,
         mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         app = FakeApp()
         app.no_args_method()
-        call_kwargs = mock_start_log.call_args[1]
+        call_kwargs = mock_complete_log.call_args[1]
         assert call_kwargs["task_size"] is None
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
@@ -280,8 +265,7 @@ class TestFunctionLog:
         _mock_register: MagicMock,
         _mock_last_seen: MagicMock,
         mock_start_log: MagicMock,
-        mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
+        _mock_complete_log: MagicMock,
     ) -> None:
         app = FakeApp(app_id="my_app", runtime="my_runtime")
         app.process_items(["x"])
@@ -289,7 +273,6 @@ class TestFunctionLog:
         assert call_kwargs["app_id"] == "my_app"
         assert call_kwargs["runtime_id"] == "my_runtime"
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
@@ -299,15 +282,13 @@ class TestFunctionLog:
         _mock_register: MagicMock,
         _mock_last_seen: MagicMock,
         mock_start_log: MagicMock,
-        mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
+        _mock_complete_log: MagicMock,
     ) -> None:
         app = FakeApp(app_id="my_app", runtime="rt")
         app.process_items(["x"])
         call_kwargs = mock_start_log.call_args[1]
         assert call_kwargs["main_app"] == "my_app"
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
@@ -317,20 +298,110 @@ class TestFunctionLog:
         _mock_register: MagicMock,
         _mock_last_seen: MagicMock,
         mock_start_log: MagicMock,
-        mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
+        _mock_complete_log: MagicMock,
     ) -> None:
         app = FakeApp(app_id="child", runtime="rt", main_app="root_app")
         app.process_items(["x"])
         call_kwargs = mock_start_log.call_args[1]
         assert call_kwargs["main_app"] == "root_app"
 
+    @patch(f"{_REGISTRY}.complete_function_log")
+    @patch(f"{_REGISTRY}.start_function_log", return_value=1)
+    @patch(f"{_REGISTRY}.update_last_seen")
+    @patch(f"{_REGISTRY}.register_function")
+    def test_complete_includes_call_count(
+        self,
+        _mock_register: MagicMock,
+        _mock_last_seen: MagicMock,
+        _mock_start_log: MagicMock,
+        mock_complete_log: MagicMock,
+    ) -> None:
+        app = FakeApp()
+        app.process_items(["a"])
+        call_kwargs = mock_complete_log.call_args[1]
+        assert call_kwargs["call_count"] == 1
+
+    @patch(f"{_REGISTRY}.complete_function_log")
+    @patch(f"{_REGISTRY}.start_function_log", return_value=1)
+    @patch(f"{_REGISTRY}.update_last_seen")
+    @patch(f"{_REGISTRY}.register_function")
+    def test_complete_includes_timing_metrics(
+        self,
+        _mock_register: MagicMock,
+        _mock_last_seen: MagicMock,
+        _mock_start_log: MagicMock,
+        mock_complete_log: MagicMock,
+    ) -> None:
+        app = FakeApp()
+        app.process_items(["a"])
+        call_kwargs = mock_complete_log.call_args[1]
+        assert "total_elapsed_ms" in call_kwargs
+        assert "average_elapsed_ms" in call_kwargs
+        assert "median_elapsed_ms" in call_kwargs
+        assert "min_elapsed_ms" in call_kwargs
+        assert "max_elapsed_ms" in call_kwargs
+
+    @patch(f"{_REGISTRY}.complete_function_log")
+    @patch(f"{_REGISTRY}.start_function_log", return_value=1)
+    @patch(f"{_REGISTRY}.update_last_seen")
+    @patch(f"{_REGISTRY}.register_function")
+    def test_start_function_log_has_log_role_function(
+        self,
+        _mock_register: MagicMock,
+        _mock_last_seen: MagicMock,
+        mock_start_log: MagicMock,
+        _mock_complete_log: MagicMock,
+    ) -> None:
+        app = FakeApp()
+        app.process_items(["a"])
+        call_kwargs = mock_start_log.call_args[1]
+        assert call_kwargs["log_role"] == "function"
+
+    @patch(f"{_REGISTRY}.complete_function_log")
+    @patch(f"{_REGISTRY}.start_function_log", return_value=1)
+    @patch(f"{_REGISTRY}.update_last_seen")
+    @patch(f"{_REGISTRY}.register_function")
+    def test_start_function_log_has_no_parent_fields(
+        self,
+        _mock_register: MagicMock,
+        _mock_last_seen: MagicMock,
+        mock_start_log: MagicMock,
+        _mock_complete_log: MagicMock,
+    ) -> None:
+        app = FakeApp()
+        app.process_items(["a"])
+        call_kwargs = mock_start_log.call_args[1]
+        assert "parent_log_id" not in call_kwargs
+        assert "execution_order" not in call_kwargs
+        assert "thread_execution_order" not in call_kwargs
+        assert "thread_id" not in call_kwargs
+
+    @patch(f"{_REGISTRY}.complete_function_log")
+    @patch(f"{_REGISTRY}.start_function_log", return_value=1)
+    @patch(f"{_REGISTRY}.update_last_seen")
+    @patch(f"{_REGISTRY}.register_function")
+    def test_aggregate_context_reused_across_invocations(
+        self,
+        _mock_register: MagicMock,
+        _mock_last_seen: MagicMock,
+        mock_start_log: MagicMock,
+        mock_complete_log: MagicMock,
+    ) -> None:
+        """Second invocation of same function reuses aggregate context -- one INSERT, two UPDATEs."""
+        app = FakeApp()
+        app.process_items(["a"])
+        app.process_items(["b", "c"])
+        assert mock_start_log.call_count == 1
+        assert mock_complete_log.call_count == 2
+        last_kwargs = mock_complete_log.call_args[1]
+        assert last_kwargs["call_count"] == 2
+        assert last_kwargs["solved"] == 3
+
 
 class TestExceptionHandling:
     def setup_method(self) -> None:
         FunWatchRegistry.reset()
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
@@ -339,16 +410,14 @@ class TestExceptionHandling:
         self,
         _mock_register: MagicMock,
         _mock_last_seen: MagicMock,
-        mock_start_log: MagicMock,
+        _mock_start_log: MagicMock,
         mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         app = FakeApp()
         with pytest.raises(ValueError, match="test error"):
             app.failing_method(["x"])
         mock_complete_log.assert_called_once()
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
@@ -357,9 +426,8 @@ class TestExceptionHandling:
         self,
         _mock_register: MagicMock,
         _mock_last_seen: MagicMock,
-        mock_start_log: MagicMock,
+        _mock_start_log: MagicMock,
         mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         app = FakeApp()
         with pytest.raises(ValueError):
@@ -367,7 +435,6 @@ class TestExceptionHandling:
         call_kwargs = mock_complete_log.call_args[1]
         assert call_kwargs["solved"] == 1
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
@@ -378,7 +445,6 @@ class TestExceptionHandling:
         _mock_last_seen: MagicMock,
         _mock_start_log: MagicMock,
         _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         app = FakeApp()
         with pytest.raises(ValueError, match="test error"):
@@ -389,7 +455,6 @@ class TestReturnValue:
     def setup_method(self) -> None:
         FunWatchRegistry.reset()
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
@@ -400,13 +465,11 @@ class TestReturnValue:
         _mock_last_seen: MagicMock,
         _mock_start_log: MagicMock,
         _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         app = FakeApp()
         result = app.process_items(["a", "b"])
         assert result == 2
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
@@ -417,7 +480,6 @@ class TestReturnValue:
         _mock_last_seen: MagicMock,
         _mock_start_log: MagicMock,
         _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         app = FakeApp()
         result = app.no_args_method()
@@ -428,18 +490,16 @@ class TestNestedInvocations:
     def setup_method(self) -> None:
         FunWatchRegistry.reset()
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
     @patch(f"{_REGISTRY}.register_function")
-    def test_nested_success_restores_outer_context(
+    def test_nested_success_each_function_gets_own_aggregate(
         self,
         _mock_register: MagicMock,
         _mock_last_seen: MagicMock,
         mock_start_log: MagicMock,
         mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         app = NestedApp()
         result = app.outer(["a", "b"], ["x", "y", "z"])
@@ -448,14 +508,6 @@ class TestNestedInvocations:
         assert mock_start_log.call_count == 2
         assert mock_complete_log.call_count == 2
 
-        start_rows = [call[1] for call in mock_start_log.call_args_list]
-        complete_rows = [call[1] for call in mock_complete_log.call_args_list]
-        assert any(row["task_size"] == 3 for row in start_rows)
-        assert any(row["task_size"] == 2 for row in start_rows)
-        assert any(row["solved"] == 3 and row["failed"] == 0 for row in complete_rows)
-        assert any(row["solved"] == 2 and row["failed"] == 2 for row in complete_rows)
-
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
@@ -466,7 +518,6 @@ class TestNestedInvocations:
         _mock_last_seen: MagicMock,
         mock_start_log: MagicMock,
         mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         app = NestedExceptionApp()
         result = app.outer_handles_inner_failure(["a", "b"], ["x", "y", "z"])
@@ -475,25 +526,16 @@ class TestNestedInvocations:
         assert mock_start_log.call_count == 2
         assert mock_complete_log.call_count == 2
 
-        start_rows = [call[1] for call in mock_start_log.call_args_list]
-        complete_rows = [call[1] for call in mock_complete_log.call_args_list]
-        assert any(row["task_size"] == 3 for row in start_rows)
-        assert any(row["task_size"] == 2 for row in start_rows)
-        assert any(row["solved"] == 0 and row["failed"] == 1 for row in complete_rows)
-        assert any(row["solved"] == 2 and row["failed"] == 3 for row in complete_rows)
-
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
     @patch(f"{_REGISTRY}.register_function")
-    def test_nested_fan_out_keeps_outer_and_inner_counters_isolated(
+    def test_nested_fan_out_keeps_contexts_isolated(
         self,
         _mock_register: MagicMock,
         _mock_last_seen: MagicMock,
         mock_start_log: MagicMock,
         mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         app = NestedFanOutApp()
         result = app.outer(6, ["a", "b", "c"], 2)
@@ -501,81 +543,6 @@ class TestNestedInvocations:
         assert result == 9
         assert mock_start_log.call_count == 2
         assert mock_complete_log.call_count == 2
-
-        start_rows = [call[1] for call in mock_start_log.call_args_list]
-        complete_rows = [call[1] for call in mock_complete_log.call_args_list]
-        assert any(row["task_size"] == 3 for row in start_rows)
-        assert any(row["task_size"] is None for row in start_rows)
-        assert any(row["solved"] == 3 and row["failed"] == 0 for row in complete_rows)
-        assert any(row["solved"] == 6 and row["failed"] == 2 for row in complete_rows)
-
-
-class TestParentLogTracking:
-    """Verify parent_log_id and log_role are set correctly for nested @fun_watch calls."""
-
-    def setup_method(self) -> None:
-        FunWatchRegistry.reset()
-        structlog.contextvars.clear_contextvars()
-
-    def teardown_method(self) -> None:
-        structlog.contextvars.clear_contextvars()
-
-    @patch(f"{_REGISTRY}.update_parent_log_role")
-    @patch(f"{_REGISTRY}.complete_function_log")
-    @patch(f"{_REGISTRY}.start_function_log", return_value=1)
-    @patch(f"{_REGISTRY}.update_last_seen")
-    @patch(f"{_REGISTRY}.register_function")
-    def test_top_level_has_no_parent(
-        self,
-        _mock_register: MagicMock,
-        _mock_last_seen: MagicMock,
-        mock_start_log: MagicMock,
-        _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
-    ) -> None:
-        app = FakeApp()
-        app.process_items(["a"])
-        call_kwargs = mock_start_log.call_args[1]
-        assert call_kwargs["parent_log_id"] is None
-        assert call_kwargs["log_role"] == "single"
-
-    @patch(f"{_REGISTRY}.update_parent_log_role")
-    @patch(f"{_REGISTRY}.complete_function_log")
-    @patch(f"{_REGISTRY}.start_function_log", return_value=1)
-    @patch(f"{_REGISTRY}.update_last_seen")
-    @patch(f"{_REGISTRY}.register_function")
-    def test_nested_child_has_parent_log_id(
-        self,
-        _mock_register: MagicMock,
-        _mock_last_seen: MagicMock,
-        mock_start_log: MagicMock,
-        _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
-    ) -> None:
-        app = NestedApp()
-        app.outer(["a"], ["x"])
-        start_rows = [call[1] for call in mock_start_log.call_args_list]
-        outer_row = next(r for r in start_rows if r["log_role"] != "child")
-        child_row = next(r for r in start_rows if r["log_role"] == "child")
-        assert outer_row["parent_log_id"] is None
-        assert child_row["parent_log_id"] == 1
-
-    @patch(f"{_REGISTRY}.update_parent_log_role")
-    @patch(f"{_REGISTRY}.complete_function_log")
-    @patch(f"{_REGISTRY}.start_function_log", return_value=1)
-    @patch(f"{_REGISTRY}.update_last_seen")
-    @patch(f"{_REGISTRY}.register_function")
-    def test_parent_role_updated_when_child_detected(
-        self,
-        _mock_register: MagicMock,
-        _mock_last_seen: MagicMock,
-        _mock_start_log: MagicMock,
-        _mock_complete_log: MagicMock,
-        mock_parent_role: MagicMock,
-    ) -> None:
-        app = NestedApp()
-        app.outer(["a"], ["x"])
-        mock_parent_role.assert_called_once_with(1)
 
 
 class TestValidation:
@@ -611,7 +578,6 @@ class TestLastSeen:
     def setup_method(self) -> None:
         FunWatchRegistry.reset()
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
@@ -622,13 +588,11 @@ class TestLastSeen:
         mock_last_seen: MagicMock,
         _mock_start_log: MagicMock,
         _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         app = FakeApp()
         app.process_items(["a"])
         mock_last_seen.assert_called_once()
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
@@ -639,7 +603,6 @@ class TestLastSeen:
         mock_last_seen: MagicMock,
         _mock_start_log: MagicMock,
         _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         app = FakeApp()
         with pytest.raises(ValueError):
@@ -657,7 +620,6 @@ class TestStructlogContextBinding:
     def teardown_method(self) -> None:
         structlog.contextvars.clear_contextvars()
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
@@ -668,7 +630,6 @@ class TestStructlogContextBinding:
         _mock_last_seen: MagicMock,
         _mock_start_log: MagicMock,
         _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         captured: dict[str, str] = {}
 
@@ -685,7 +646,6 @@ class TestStructlogContextBinding:
         app.do_work(["a"])
         assert captured["function_id"] != ""
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
@@ -696,7 +656,6 @@ class TestStructlogContextBinding:
         _mock_last_seen: MagicMock,
         _mock_start_log: MagicMock,
         _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         class SimpleApp(FunWatchMixin):
             app_id = "unbind_test_app"
@@ -711,7 +670,6 @@ class TestStructlogContextBinding:
         structlog_context = structlog.contextvars.get_contextvars()
         assert "function_id" not in structlog_context
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
@@ -722,7 +680,6 @@ class TestStructlogContextBinding:
         _mock_last_seen: MagicMock,
         _mock_start_log: MagicMock,
         _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         captured: dict[str, int] = {}
 
@@ -739,7 +696,6 @@ class TestStructlogContextBinding:
         app.do_work(["a"])
         assert captured["thread_id"] == threading.get_ident()
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
@@ -750,7 +706,6 @@ class TestStructlogContextBinding:
         _mock_last_seen: MagicMock,
         _mock_start_log: MagicMock,
         _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         class SimpleApp(FunWatchMixin):
             app_id = "unbind_thread_app"
@@ -765,7 +720,6 @@ class TestStructlogContextBinding:
         structlog_context = structlog.contextvars.get_contextvars()
         assert "thread_id" not in structlog_context
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
@@ -776,7 +730,6 @@ class TestStructlogContextBinding:
         _mock_last_seen: MagicMock,
         _mock_start_log: MagicMock,
         _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         captured_outer_before: dict[str, str] = {}
         captured_inner: dict[str, str] = {}
@@ -807,7 +760,6 @@ class TestStructlogContextBinding:
         assert captured_inner["function_id"] != captured_outer_before["function_id"]
         assert captured_outer_after["function_id"] == captured_outer_before["function_id"]
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
@@ -818,7 +770,6 @@ class TestStructlogContextBinding:
         _mock_last_seen: MagicMock,
         _mock_start_log: MagicMock,
         _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         captured: dict[str, str] = {}
 
@@ -836,7 +787,6 @@ class TestStructlogContextBinding:
         assert captured["call_chain"].endswith("-> ChainApp.do_work")
         assert "ChainApp.do_work" in captured["call_chain"]
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
@@ -847,7 +797,6 @@ class TestStructlogContextBinding:
         _mock_last_seen: MagicMock,
         _mock_start_log: MagicMock,
         _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         captured_inner: dict[str, str] = {}
 
@@ -868,7 +817,6 @@ class TestStructlogContextBinding:
         app.outer()
         assert captured_inner["call_chain"].endswith("NestingChainApp.outer -> NestingChainApp.inner")
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
@@ -879,7 +827,6 @@ class TestStructlogContextBinding:
         _mock_last_seen: MagicMock,
         _mock_start_log: MagicMock,
         _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         captured_before: dict[str, str] = {}
         captured_after: dict[str, str] = {}
@@ -905,7 +852,6 @@ class TestStructlogContextBinding:
         assert captured_before["call_chain"].endswith("RestoreChainApp.outer")
         assert captured_after["call_chain"] == captured_before["call_chain"]
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
@@ -916,7 +862,6 @@ class TestStructlogContextBinding:
         _mock_last_seen: MagicMock,
         _mock_start_log: MagicMock,
         _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         class UnbindChainApp(FunWatchMixin):
             app_id = "unbind_chain_app"
@@ -931,7 +876,6 @@ class TestStructlogContextBinding:
         structlog_context = structlog.contextvars.get_contextvars()
         assert "call_chain" not in structlog_context
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
@@ -942,7 +886,6 @@ class TestStructlogContextBinding:
         _mock_last_seen: MagicMock,
         _mock_start_log: MagicMock,
         _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         class FailingApp(FunWatchMixin):
             app_id = "fail_ctx_app"
@@ -969,7 +912,6 @@ class TestExceptionLogging:
     def teardown_method(self) -> None:
         structlog.contextvars.clear_contextvars()
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
@@ -982,7 +924,6 @@ class TestExceptionLogging:
         _mock_last_seen: MagicMock,
         _mock_start_log: MagicMock,
         _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         class FailApp(FunWatchMixin):
             app_id = "log_exc_app"
@@ -1014,7 +955,6 @@ class TestLifecycleLogging:
     def teardown_method(self) -> None:
         structlog.contextvars.clear_contextvars()
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
@@ -1027,7 +967,6 @@ class TestLifecycleLogging:
         _mock_last_seen: MagicMock,
         _mock_start_log: MagicMock,
         _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         app = FakeApp()
         app.process_items(["a"])
@@ -1035,7 +974,6 @@ class TestLifecycleLogging:
         assert len(started_calls) == 1
         assert started_calls[0][1]["function_name"] == "process_items"
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
@@ -1048,7 +986,6 @@ class TestLifecycleLogging:
         _mock_last_seen: MagicMock,
         _mock_start_log: MagicMock,
         _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         app = FakeApp()
         app.no_args_method()
@@ -1056,7 +993,6 @@ class TestLifecycleLogging:
         assert len(started_calls) == 1
         assert "task_size" not in started_calls[0][1]
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
@@ -1069,7 +1005,6 @@ class TestLifecycleLogging:
         _mock_last_seen: MagicMock,
         _mock_start_log: MagicMock,
         _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         app = FakeApp()
         app.process_items(["a", "b", "c"])
@@ -1077,7 +1012,6 @@ class TestLifecycleLogging:
         assert len(started_calls) == 1
         assert started_calls[0][1]["task_size"] == 3
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
@@ -1090,7 +1024,6 @@ class TestLifecycleLogging:
         _mock_last_seen: MagicMock,
         _mock_start_log: MagicMock,
         _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         app = FakeApp()
         app.process_items(["a", "b", "c"])
@@ -1103,9 +1036,9 @@ class TestLifecycleLogging:
         assert kwargs["processed_count"] == 3
         assert kwargs["is_success"] is True
         assert kwargs["task_size"] == 3
+        assert kwargs["call_count"] == 1
         assert "duration_s" in kwargs
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
@@ -1118,7 +1051,6 @@ class TestLifecycleLogging:
         _mock_last_seen: MagicMock,
         _mock_start_log: MagicMock,
         _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         app = FakeApp()
         with pytest.raises(ValueError):
@@ -1128,7 +1060,6 @@ class TestLifecycleLogging:
         started_calls = [c for c in mock_logger.log.call_args_list if c[0][1] == "Function started"]
         assert len(started_calls) == 1
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
@@ -1141,7 +1072,6 @@ class TestLifecycleLogging:
         _mock_last_seen: MagicMock,
         _mock_start_log: MagicMock,
         _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         app = FakeApp()
         app.process_items(["a"])
@@ -1150,7 +1080,6 @@ class TestLifecycleLogging:
         completed_calls = [c for c in mock_logger.log.call_args_list if c[0][1] == "Function completed"]
         assert completed_calls[0][1]["call_chain"].endswith("FakeApp.process_items")
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
@@ -1163,7 +1092,6 @@ class TestLifecycleLogging:
         _mock_last_seen: MagicMock,
         _mock_start_log: MagicMock,
         _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         app = FakeApp()
         app.process_items(["a"])
@@ -1178,7 +1106,6 @@ class TestLifecycleLogging:
         assert kwargs["module_name"] == "test_decorator.py"
         assert kwargs["module_path"].endswith("test_decorator.py")
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
@@ -1191,7 +1118,6 @@ class TestLifecycleLogging:
         _mock_last_seen: MagicMock,
         _mock_start_log: MagicMock,
         _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         app = FakeApp()
         with pytest.raises(ValueError):
@@ -1199,713 +1125,3 @@ class TestLifecycleLogging:
         kwargs = mock_logger.exception.call_args[1]
         assert kwargs["module_name"] == "test_decorator.py"
         assert kwargs["module_path"].endswith("test_decorator.py")
-
-    @patch(f"{_REGISTRY}.update_parent_log_role")
-    @patch(f"{_REGISTRY}.complete_function_log")
-    @patch(f"{_REGISTRY}.start_function_log", return_value=1)
-    @patch(f"{_REGISTRY}.update_last_seen")
-    @patch(f"{_REGISTRY}.register_function")
-    def test_uses_app_logger_when_available(
-        self,
-        _mock_register: MagicMock,
-        _mock_last_seen: MagicMock,
-        _mock_start_log: MagicMock,
-        _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
-    ) -> None:
-        mock_app_logger = MagicMock()
-
-        class AppWithLogger(FunWatchMixin):
-            app_id = "logger_test_app"
-            runtime = "logger_test_runtime"
-            logger = mock_app_logger
-
-            @fun_watch
-            def do_work(self, items: list[str]) -> int:
-                for _item in items:
-                    self._fun_watch.mark_solved()
-                return len(items)
-
-        app = AppWithLogger()
-        app.do_work(["a", "b"])
-        started_calls = [c for c in mock_app_logger.log.call_args_list if c[0][1] == "Function started"]
-        assert len(started_calls) == 1
-        completed_calls = [c for c in mock_app_logger.log.call_args_list if c[0][1] == "Function completed"]
-        assert len(completed_calls) == 1
-        assert completed_calls[0][1]["solved"] == 2
-
-    @patch(f"{_REGISTRY}.update_parent_log_role")
-    @patch(f"{_REGISTRY}.complete_function_log")
-    @patch(f"{_REGISTRY}.start_function_log", return_value=1)
-    @patch(f"{_REGISTRY}.update_last_seen")
-    @patch(f"{_REGISTRY}.register_function")
-    def test_exception_logged_via_app_logger(
-        self,
-        _mock_register: MagicMock,
-        _mock_last_seen: MagicMock,
-        _mock_start_log: MagicMock,
-        _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
-    ) -> None:
-        mock_app_logger = MagicMock()
-
-        class AppWithLogger(FunWatchMixin):
-            app_id = "exc_logger_app"
-            runtime = "exc_logger_runtime"
-            logger = mock_app_logger
-
-            @fun_watch
-            def do_fail(self) -> None:
-                raise RuntimeError("boom")
-
-        app = AppWithLogger()
-        with pytest.raises(RuntimeError):
-            app.do_fail()
-        mock_app_logger.exception.assert_called_once()
-        assert mock_app_logger.exception.call_args[0][0] == "Unhandled exception in @fun_watch decorated function"
-
-
-class TestErrorColumnPropagation:
-    """Verify that error details are forwarded to complete_function_log."""
-
-    def setup_method(self) -> None:
-        FunWatchRegistry.reset()
-
-    @patch(f"{_REGISTRY}.update_parent_log_role")
-    @patch(f"{_REGISTRY}.complete_function_log")
-    @patch(f"{_REGISTRY}.start_function_log", return_value=1)
-    @patch(f"{_REGISTRY}.update_last_seen")
-    @patch(f"{_REGISTRY}.register_function")
-    def test_unhandled_exception_sets_error_type_and_message(
-        self,
-        _mock_register: MagicMock,
-        _mock_last_seen: MagicMock,
-        _mock_start_log: MagicMock,
-        mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
-    ) -> None:
-        app = FakeApp()
-        with pytest.raises(ValueError, match="test error"):
-            app.failing_method(["x"])
-        kw = mock_complete_log.call_args[1]
-        assert kw["exc_occurred"] is True
-        assert kw["error_type"] == "ValueError"
-        assert kw["error_message"] == "test error"
-
-    @patch(f"{_REGISTRY}.update_parent_log_role")
-    @patch(f"{_REGISTRY}.complete_function_log")
-    @patch(f"{_REGISTRY}.start_function_log", return_value=1)
-    @patch(f"{_REGISTRY}.update_last_seen")
-    @patch(f"{_REGISTRY}.register_function")
-    def test_success_has_no_error_info(
-        self,
-        _mock_register: MagicMock,
-        _mock_last_seen: MagicMock,
-        _mock_start_log: MagicMock,
-        mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
-    ) -> None:
-        app = FakeApp()
-        app.process_items(["a", "b"])
-        kw = mock_complete_log.call_args[1]
-        assert kw["exc_occurred"] is False
-        assert kw["error_type"] is None
-        assert kw["error_message"] is None
-
-    @patch(f"{_REGISTRY}.update_parent_log_role")
-    @patch(f"{_REGISTRY}.complete_function_log")
-    @patch(f"{_REGISTRY}.start_function_log", return_value=1)
-    @patch(f"{_REGISTRY}.update_last_seen")
-    @patch(f"{_REGISTRY}.register_function")
-    def test_mark_failed_with_error_type_propagates_item_errors(
-        self,
-        _mock_register: MagicMock,
-        _mock_last_seen: MagicMock,
-        _mock_start_log: MagicMock,
-        mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
-    ) -> None:
-        class ErrorTrackingApp(FunWatchMixin):
-            app_id = "err_track_app"
-            runtime = "err_track_runtime"
-
-            @fun_watch
-            def partial_fail(self, items: list[str]) -> None:
-                for i, _item in enumerate(items):
-                    if i >= 2:
-                        self._fun_watch.mark_failed(
-                            len(items) - i,
-                            error_type="ProcessingError",
-                            error_message="item failed",
-                        )
-                        raise RuntimeError("partial failure")
-                    self._fun_watch.mark_solved()
-
-        app = ErrorTrackingApp()
-        with pytest.raises(RuntimeError):
-            app.partial_fail(["a", "b", "c", "d"])
-        kw = mock_complete_log.call_args[1]
-        assert kw["exc_occurred"] is True
-        assert kw["error_type"] == "RuntimeError"
-        assert kw["error_message"] == "partial failure"
-        assert kw["item_error_count"] == 2
-        assert kw["item_error_types_json"] is not None
-        assert "ProcessingError" in kw["item_error_types_json"]
-
-
-class TestTaskSizeOptOut:
-    """Verify task_size=False skips auto-detection from list args."""
-
-    def setup_method(self) -> None:
-        FunWatchRegistry.reset()
-        structlog.contextvars.clear_contextvars()
-
-    def teardown_method(self) -> None:
-        structlog.contextvars.clear_contextvars()
-
-    @patch(f"{_REGISTRY}.update_parent_log_role")
-    @patch(f"{_REGISTRY}.complete_function_log")
-    @patch(f"{_REGISTRY}.start_function_log", return_value=1)
-    @patch(f"{_REGISTRY}.update_last_seen")
-    @patch(f"{_REGISTRY}.register_function")
-    def test_task_size_false_skips_detection(
-        self,
-        _mock_register: MagicMock,
-        _mock_last_seen: MagicMock,
-        mock_start_log: MagicMock,
-        _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
-    ) -> None:
-        class App(FunWatchMixin):
-            app_id = "test_app"
-            runtime = "test_runtime"
-
-            @fun_watch(task_size=False)
-            def store(self, records: list[str]) -> None:
-                pass
-
-        app = App()
-        app.store(["a", "b", "c"])
-        kw = mock_start_log.call_args[1]
-        assert kw["task_size"] is None
-
-    @patch(f"{_REGISTRY}.update_parent_log_role")
-    @patch(f"{_REGISTRY}.complete_function_log")
-    @patch(f"{_REGISTRY}.start_function_log", return_value=1)
-    @patch(f"{_REGISTRY}.update_last_seen")
-    @patch(f"{_REGISTRY}.register_function")
-    def test_bare_decorator_detects_task_size(
-        self,
-        _mock_register: MagicMock,
-        _mock_last_seen: MagicMock,
-        mock_start_log: MagicMock,
-        _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
-    ) -> None:
-        class App(FunWatchMixin):
-            app_id = "test_app"
-            runtime = "test_runtime"
-
-            @fun_watch
-            def store(self, records: list[str]) -> None:
-                pass
-
-        app = App()
-        app.store(["a", "b", "c"])
-        kw = mock_start_log.call_args[1]
-        assert kw["task_size"] == 3
-
-    @patch(f"{_REGISTRY}.update_parent_log_role")
-    @patch(f"{_REGISTRY}.complete_function_log")
-    @patch(f"{_REGISTRY}.start_function_log", return_value=1)
-    @patch(f"{_REGISTRY}.update_last_seen")
-    @patch(f"{_REGISTRY}.register_function")
-    def test_task_size_true_explicit(
-        self,
-        _mock_register: MagicMock,
-        _mock_last_seen: MagicMock,
-        mock_start_log: MagicMock,
-        _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
-    ) -> None:
-        class App(FunWatchMixin):
-            app_id = "test_app"
-            runtime = "test_runtime"
-
-            @fun_watch(task_size=True)
-            def store(self, records: list[str]) -> None:
-                pass
-
-        app = App()
-        app.store(["a", "b", "c"])
-        kw = mock_start_log.call_args[1]
-        assert kw["task_size"] == 3
-
-
-class TestLogLifecycleControl:
-    """Verify log_lifecycle and log_level parameters."""
-
-    def setup_method(self) -> None:
-        FunWatchRegistry.reset()
-        structlog.contextvars.clear_contextvars()
-
-    def teardown_method(self) -> None:
-        structlog.contextvars.clear_contextvars()
-
-    @patch(f"{_REGISTRY}.update_parent_log_role")
-    @patch(f"{_REGISTRY}.complete_function_log")
-    @patch(f"{_REGISTRY}.start_function_log", return_value=1)
-    @patch(f"{_REGISTRY}.update_last_seen")
-    @patch(f"{_REGISTRY}.register_function")
-    def test_log_lifecycle_false_suppresses_lifecycle_logs(
-        self,
-        _mock_register: MagicMock,
-        _mock_last_seen: MagicMock,
-        _mock_start_log: MagicMock,
-        _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
-    ) -> None:
-        mock_logger = MagicMock()
-
-        class App(FunWatchMixin):
-            app_id = "test_app"
-            runtime = "test_runtime"
-            logger = mock_logger
-
-            @fun_watch(log_lifecycle=False)
-            def process(self) -> None:
-                pass
-
-        app = App()
-        app.process()
-        mock_logger.log.assert_not_called()
-
-    @patch(f"{_REGISTRY}.update_parent_log_role")
-    @patch(f"{_REGISTRY}.complete_function_log")
-    @patch(f"{_REGISTRY}.start_function_log", return_value=1)
-    @patch(f"{_REGISTRY}.update_last_seen")
-    @patch(f"{_REGISTRY}.register_function")
-    def test_log_lifecycle_false_still_writes_function_log(
-        self,
-        _mock_register: MagicMock,
-        _mock_last_seen: MagicMock,
-        mock_start_log: MagicMock,
-        mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
-    ) -> None:
-        class App(FunWatchMixin):
-            app_id = "test_app"
-            runtime = "test_runtime"
-            logger = MagicMock()
-
-            @fun_watch(log_lifecycle=False)
-            def process(self) -> None:
-                pass
-
-        app = App()
-        app.process()
-        mock_start_log.assert_called_once()
-        mock_complete_log.assert_called_once()
-
-    @patch(f"{_REGISTRY}.update_parent_log_role")
-    @patch(f"{_REGISTRY}.complete_function_log")
-    @patch(f"{_REGISTRY}.start_function_log", return_value=1)
-    @patch(f"{_REGISTRY}.update_last_seen")
-    @patch(f"{_REGISTRY}.register_function")
-    def test_log_lifecycle_false_still_logs_exceptions(
-        self,
-        _mock_register: MagicMock,
-        _mock_last_seen: MagicMock,
-        _mock_start_log: MagicMock,
-        _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
-    ) -> None:
-        mock_logger = MagicMock()
-
-        class App(FunWatchMixin):
-            app_id = "test_app"
-            runtime = "test_runtime"
-            logger = mock_logger
-
-            @fun_watch(log_lifecycle=False)
-            def process(self) -> None:
-                raise ValueError("test")
-
-        app = App()
-        with pytest.raises(ValueError):
-            app.process()
-        mock_logger.exception.assert_called_once()
-
-    @patch(f"{_REGISTRY}.update_parent_log_role")
-    @patch(f"{_REGISTRY}.complete_function_log")
-    @patch(f"{_REGISTRY}.start_function_log", return_value=1)
-    @patch(f"{_REGISTRY}.update_last_seen")
-    @patch(f"{_REGISTRY}.register_function")
-    def test_log_lifecycle_true_default(
-        self,
-        _mock_register: MagicMock,
-        _mock_last_seen: MagicMock,
-        _mock_start_log: MagicMock,
-        _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
-    ) -> None:
-        mock_logger = MagicMock()
-
-        class App(FunWatchMixin):
-            app_id = "test_app"
-            runtime = "test_runtime"
-            logger = mock_logger
-
-            @fun_watch
-            def process(self) -> None:
-                pass
-
-        app = App()
-        app.process()
-        log_calls = mock_logger.log.call_args_list
-        assert len(log_calls) == 2
-        assert log_calls[0][0][1] == "Function started"
-        assert log_calls[1][0][1] == "Function completed"
-
-    @patch(f"{_REGISTRY}.update_parent_log_role")
-    @patch(f"{_REGISTRY}.complete_function_log")
-    @patch(f"{_REGISTRY}.start_function_log", return_value=1)
-    @patch(f"{_REGISTRY}.update_last_seen")
-    @patch(f"{_REGISTRY}.register_function")
-    def test_log_level_info_emits_at_info(
-        self,
-        _mock_register: MagicMock,
-        _mock_last_seen: MagicMock,
-        _mock_start_log: MagicMock,
-        _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
-    ) -> None:
-        import logging
-
-        mock_logger = MagicMock()
-
-        class App(FunWatchMixin):
-            app_id = "test_app"
-            runtime = "test_runtime"
-            logger = mock_logger
-
-            @fun_watch(log_level=logging.INFO)
-            def process(self) -> None:
-                pass
-
-        app = App()
-        app.process()
-        log_calls = mock_logger.log.call_args_list
-        assert log_calls[0][0][0] == logging.INFO
-        assert log_calls[1][0][0] == logging.INFO
-
-    @patch(f"{_REGISTRY}.update_parent_log_role")
-    @patch(f"{_REGISTRY}.complete_function_log")
-    @patch(f"{_REGISTRY}.start_function_log", return_value=1)
-    @patch(f"{_REGISTRY}.update_last_seen")
-    @patch(f"{_REGISTRY}.register_function")
-    def test_log_level_does_not_affect_exception_log(
-        self,
-        _mock_register: MagicMock,
-        _mock_last_seen: MagicMock,
-        _mock_start_log: MagicMock,
-        _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
-    ) -> None:
-        import logging
-
-        mock_logger = MagicMock()
-
-        class App(FunWatchMixin):
-            app_id = "test_app"
-            runtime = "test_runtime"
-            logger = mock_logger
-
-            @fun_watch(log_level=logging.WARNING)
-            def process(self) -> None:
-                raise RuntimeError("boom")
-
-        app = App()
-        with pytest.raises(RuntimeError):
-            app.process()
-        mock_logger.exception.assert_called_once()
-
-    @patch(f"{_REGISTRY}.update_parent_log_role")
-    @patch(f"{_REGISTRY}.complete_function_log")
-    @patch(f"{_REGISTRY}.start_function_log", return_value=1)
-    @patch(f"{_REGISTRY}.update_last_seen")
-    @patch(f"{_REGISTRY}.register_function")
-    def test_log_level_none_uses_registry_default(
-        self,
-        _mock_register: MagicMock,
-        _mock_last_seen: MagicMock,
-        _mock_start_log: MagicMock,
-        _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
-    ) -> None:
-        import logging
-
-        FunWatchRegistry.instance().set_default_lifecycle_log_level(logging.INFO)
-        mock_logger = MagicMock()
-
-        class App(FunWatchMixin):
-            app_id = "test_app"
-            runtime = "test_runtime"
-            logger = mock_logger
-
-            @fun_watch
-            def process(self) -> None:
-                pass
-
-        app = App()
-        app.process()
-        log_calls = mock_logger.log.call_args_list
-        assert log_calls[0][0][0] == logging.INFO
-
-    @patch(f"{_REGISTRY}.update_parent_log_role")
-    @patch(f"{_REGISTRY}.complete_function_log")
-    @patch(f"{_REGISTRY}.start_function_log", return_value=1)
-    @patch(f"{_REGISTRY}.update_last_seen")
-    @patch(f"{_REGISTRY}.register_function")
-    def test_log_level_explicit_overrides_registry(
-        self,
-        _mock_register: MagicMock,
-        _mock_last_seen: MagicMock,
-        _mock_start_log: MagicMock,
-        _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
-    ) -> None:
-        import logging
-
-        FunWatchRegistry.instance().set_default_lifecycle_log_level(logging.INFO)
-        mock_logger = MagicMock()
-
-        class App(FunWatchMixin):
-            app_id = "test_app"
-            runtime = "test_runtime"
-            logger = mock_logger
-
-            @fun_watch(log_level=logging.WARNING)
-            def process(self) -> None:
-                pass
-
-        app = App()
-        app.process()
-        log_calls = mock_logger.log.call_args_list
-        assert log_calls[0][0][0] == logging.WARNING
-
-
-class TestExecutionOrderCounters:
-    """Verify global vs per-thread execution order counters."""
-
-    def setup_method(self) -> None:
-        FunWatchRegistry.reset()
-
-    def test_global_order_increments_across_threads(self) -> None:
-        registry = FunWatchRegistry.instance()
-        g1, _t1 = registry.next_execution_order("rt1", 100)
-        g2, _t2 = registry.next_execution_order("rt1", 200)
-        g3, _t3 = registry.next_execution_order("rt1", 100)
-        g4, _t4 = registry.next_execution_order("rt1", 200)
-        assert [g1, g2, g3, g4] == [1, 2, 3, 4]
-
-    def test_thread_order_independent_per_thread(self) -> None:
-        registry = FunWatchRegistry.instance()
-        _g1, t1 = registry.next_execution_order("rt1", 100)
-        _g2, t2 = registry.next_execution_order("rt1", 200)
-        _g3, t3 = registry.next_execution_order("rt1", 100)
-        _g4, t4 = registry.next_execution_order("rt1", 200)
-        assert [t1, t3] == [1, 2]
-        assert [t2, t4] == [1, 2]
-
-    def test_single_thread_both_orders_equal(self) -> None:
-        registry = FunWatchRegistry.instance()
-        g1, t1 = registry.next_execution_order("rt1", 100)
-        g2, t2 = registry.next_execution_order("rt1", 100)
-        assert g1 == t1 == 1
-        assert g2 == t2 == 2
-
-
-class TestLifecycleLogFields:
-    """Verify lifecycle logs include log_id and execution_order for correlation."""
-
-    def setup_method(self) -> None:
-        FunWatchRegistry.reset()
-        structlog.contextvars.clear_contextvars()
-
-    def teardown_method(self) -> None:
-        structlog.contextvars.clear_contextvars()
-
-    @patch(f"{_REGISTRY}.update_parent_log_role")
-    @patch(f"{_REGISTRY}.complete_function_log")
-    @patch(f"{_REGISTRY}.start_function_log", return_value=42)
-    @patch(f"{_REGISTRY}.update_last_seen")
-    @patch(f"{_REGISTRY}.register_function")
-    def test_started_log_includes_log_id_and_execution_order(
-        self,
-        _mock_register: MagicMock,
-        _mock_last_seen: MagicMock,
-        _mock_start_log: MagicMock,
-        _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
-    ) -> None:
-        mock_logger = MagicMock()
-
-        class App(FunWatchMixin):
-            app_id = "test_app"
-            runtime = "test_runtime"
-            logger = mock_logger
-
-            @fun_watch
-            def process(self) -> None:
-                pass
-
-        app = App()
-        app.process()
-        started_call = mock_logger.log.call_args_list[0]
-        kwargs = started_call[1]
-        assert kwargs["log_id"] == 42
-        assert kwargs["execution_order"] == 1
-        assert kwargs["log_role"] == "single"
-
-    @patch(f"{_REGISTRY}.update_parent_log_role")
-    @patch(f"{_REGISTRY}.complete_function_log")
-    @patch(f"{_REGISTRY}.start_function_log", return_value=42)
-    @patch(f"{_REGISTRY}.update_last_seen")
-    @patch(f"{_REGISTRY}.register_function")
-    def test_completed_log_includes_log_id(
-        self,
-        _mock_register: MagicMock,
-        _mock_last_seen: MagicMock,
-        _mock_start_log: MagicMock,
-        _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
-    ) -> None:
-        mock_logger = MagicMock()
-
-        class App(FunWatchMixin):
-            app_id = "test_app"
-            runtime = "test_runtime"
-            logger = mock_logger
-
-            @fun_watch
-            def process(self) -> None:
-                pass
-
-        app = App()
-        app.process()
-        completed_call = mock_logger.log.call_args_list[1]
-        kwargs = completed_call[1]
-        assert kwargs["log_id"] == 42
-
-    @patch(f"{_REGISTRY}.update_parent_log_role")
-    @patch(f"{_REGISTRY}.complete_function_log")
-    @patch(f"{_REGISTRY}.start_function_log", return_value=42)
-    @patch(f"{_REGISTRY}.update_last_seen")
-    @patch(f"{_REGISTRY}.register_function")
-    def test_exception_log_includes_log_id(
-        self,
-        _mock_register: MagicMock,
-        _mock_last_seen: MagicMock,
-        _mock_start_log: MagicMock,
-        _mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
-    ) -> None:
-        mock_logger = MagicMock()
-
-        class App(FunWatchMixin):
-            app_id = "test_app"
-            runtime = "test_runtime"
-            logger = mock_logger
-
-            @fun_watch
-            def process(self) -> None:
-                raise ValueError("test")
-
-        app = App()
-        with pytest.raises(ValueError):
-            app.process()
-        exception_call = mock_logger.exception.call_args
-        kwargs = exception_call[1]
-        assert kwargs["log_id"] == 42
-
-
-class TestModulePathResolution:
-    """Test that module_path resolves to instance class for inherited methods."""
-
-    def setup_method(self) -> None:
-        FunWatchRegistry.reset()
-
-    @patch(f"{_REGISTRY}.update_parent_log_role")
-    @patch(f"{_REGISTRY}.complete_function_log")
-    @patch(f"{_REGISTRY}.start_function_log", return_value=1)
-    @patch(f"{_REGISTRY}.update_last_seen")
-    @patch(f"{_REGISTRY}.register_function")
-    def test_own_method_uses_definition_file(
-        self,
-        mock_register: MagicMock,
-        mock_last_seen: MagicMock,
-        mock_start_log: MagicMock,
-        mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
-    ) -> None:
-        mock_logger = MagicMock()
-
-        class App(FunWatchMixin):
-            app_id = "test_app"
-            runtime = "test_runtime"
-            logger = mock_logger
-
-            @fun_watch
-            def do_work(self) -> None:
-                pass
-
-        app = App()
-        app.do_work()
-
-        log_call = mock_logger.log.call_args
-        assert log_call is not None
-        assert log_call[1]["module_name"] == "test_decorator.py"
-        assert "test_decorator.py" in log_call[1]["module_path"]
-
-    @patch(f"{_REGISTRY}.update_parent_log_role")
-    @patch(f"{_REGISTRY}.complete_function_log")
-    @patch(f"{_REGISTRY}.start_function_log", return_value=1)
-    @patch(f"{_REGISTRY}.update_last_seen")
-    @patch(f"{_REGISTRY}.register_function")
-    def test_inherited_method_resolves_to_instance_class_module(
-        self,
-        mock_register: MagicMock,
-        mock_last_seen: MagicMock,
-        mock_start_log: MagicMock,
-        mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
-    ) -> None:
-        """When a @fun_watch method is inherited, module_path resolves to the subclass module."""
-        mock_logger = MagicMock()
-
-        class Base(FunWatchMixin):
-            @fun_watch
-            def inherited_work(self) -> None:
-                pass
-
-        class Child(Base):
-            app_id = "test_app"
-            runtime = "test_runtime"
-            logger = mock_logger
-
-        # Simulate cross-module inheritance by patching the decorated func's __module__
-        original_method = Base.__dict__["inherited_work"]
-        original_module = original_method.__module__
-        original_method.__module__ = "data_collector.scraping.threaded"
-        try:
-            app = Child()
-            app.inherited_work()
-
-            log_call = mock_logger.log.call_args
-            assert log_call is not None
-            # module_path should resolve to the test file (Child's module), not threaded
-            assert log_call[1]["module_name"] == "test_decorator.py"
-            assert "test_decorator.py" in log_call[1]["module_path"]
-        finally:
-            original_method.__module__ = original_module

--- a/tests/unit/fun_watch/test_tables.py
+++ b/tests/unit/fun_watch/test_tables.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-from sqlalchemy import BigInteger
 from sqlalchemy import inspect as sa_inspect
 
 from data_collector.tables.apps import AppFunctions
-from data_collector.tables.log import FunctionLog, FunctionLogError
+from data_collector.tables.log import FunctionLog
 
 
 class TestAppFunctions:
@@ -51,14 +50,32 @@ class TestFunctionLog:
     def test_columns_present(self) -> None:
         columns = {c.name for c in sa_inspect(FunctionLog).columns}
         expected = {
-            "id", "function_hash", "execution_order", "thread_execution_order",
-            "log_role", "parent_log_id", "main_app", "app_id",
-            "thread_id", "task_size", "solved", "failed",
+            "id", "function_hash", "log_role", "main_app", "app_id",
+            "call_count", "task_size", "solved", "failed",
             "processed_count", "is_success",
-            "start_time", "end_time", "totals", "totalm", "totalh",
-            "runtime", "date_created",
+            "start_time", "end_time",
+            "total_elapsed_ms", "average_elapsed_ms", "median_elapsed_ms",
+            "min_elapsed_ms", "max_elapsed_ms",
+            "caller_log_id", "runtime", "date_created",
         }
         assert expected.issubset(columns)
+
+    def test_removed_columns_absent(self) -> None:
+        columns = {c.name for c in sa_inspect(FunctionLog).columns}
+        removed = {
+            "execution_order", "thread_execution_order", "parent_log_id",
+            "thread_id", "totals", "totalm", "totalh",
+        }
+        assert removed.isdisjoint(columns)
+
+    def test_unique_constraint_function_hash_runtime(self) -> None:
+        constraints = FunctionLog.__table__.constraints
+        unique_constraints = [c for c in constraints if hasattr(c, "columns") and len(c.columns) == 2]
+        found = any(
+            {col.name for col in c.columns} == {"function_hash", "runtime"}
+            for c in unique_constraints
+        )
+        assert found, "UniqueConstraint on (function_hash, runtime) not found"
 
     def test_function_hash_foreign_key(self) -> None:
         fks = {fk.target_fullname for fk in FunctionLog.__table__.foreign_keys}
@@ -68,40 +85,14 @@ class TestFunctionLog:
         fks = {fk.target_fullname for fk in FunctionLog.__table__.foreign_keys}
         assert "runtime.runtime" in fks
 
-    def test_thread_id_is_big_integer(self) -> None:
-        col = FunctionLog.__table__.c.thread_id
-        assert isinstance(col.type, BigInteger)
-
     def test_indexed_columns(self) -> None:
         table = FunctionLog.__table__
         for col_name in ("function_hash", "main_app", "app_id", "runtime"):
             assert table.c[col_name].index is True, f"{col_name} should be indexed"
 
-
-class TestFunctionLogError:
-    def test_tablename(self) -> None:
-        assert FunctionLogError.__tablename__ == "function_log_error"
-
-    def test_columns_present(self) -> None:
-        columns = {c.name for c in sa_inspect(FunctionLogError).columns}
-        expected = {
-            "id", "function_log_id", "error_type", "error_message", "item_error_count",
-            "item_error_types_json", "item_error_samples_json", "date_created",
-        }
-        assert expected.issubset(columns)
-
-    def test_function_log_id_foreign_key(self) -> None:
-        fks = {fk.target_fullname for fk in FunctionLogError.__table__.foreign_keys}
-        assert "function_log.id" in fks
-
-    def test_function_log_id_unique_and_not_nullable(self) -> None:
-        col = FunctionLogError.__table__.c.function_log_id
-        assert col.unique is True
-        assert col.nullable is False
-
-    def test_function_log_id_indexed(self) -> None:
-        col = FunctionLogError.__table__.c.function_log_id
-        assert col.index is True
+    def test_function_log_error_table_removed(self) -> None:
+        from data_collector.tables import log
+        assert not hasattr(log, "FunctionLogError"), "FunctionLogError table should be removed"
 
 
 class TestExports:
@@ -113,6 +104,6 @@ class TestExports:
         from data_collector.tables import FunctionLog as Exported
         assert Exported is FunctionLog
 
-    def test_function_log_error_exported(self) -> None:
-        from data_collector.tables import FunctionLogError as Exported
-        assert Exported is FunctionLogError
+    def test_function_log_error_not_exported(self) -> None:
+        import data_collector.tables as tables_module
+        assert not hasattr(tables_module, "FunctionLogError")

--- a/tests/unit/fun_watch/test_thread_safety.py
+++ b/tests/unit/fun_watch/test_thread_safety.py
@@ -147,19 +147,18 @@ class TestConcurrentCalls:
     def setup_method(self) -> None:
         FunWatchRegistry.reset()
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
     @patch(f"{_REGISTRY}.register_function")
-    def test_independent_solved_counters(
+    def test_aggregate_solved_counters_across_threads(
         self,
-        mock_register: MagicMock,
-        mock_last_seen: MagicMock,
+        _mock_register: MagicMock,
+        _mock_last_seen: MagicMock,
         mock_start_log: MagicMock,
         mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
+        """All concurrent calls to same function share one aggregate context."""
         app = ThreadApp()
         results: list[int] = []
 
@@ -172,47 +171,25 @@ class TestConcurrentCalls:
                 results.append(future.result())
 
         assert len(results) == 8
+        assert mock_start_log.call_count == 1
         assert mock_complete_log.call_count == 8
 
-        for call in mock_complete_log.call_args_list:
-            assert call[1]["solved"] == 10
+        last_call = mock_complete_log.call_args_list[-1]
+        assert last_call[1]["call_count"] == 8
+        assert last_call[1]["solved"] == 80
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
     @patch(f"{_REGISTRY}.register_function")
-    def test_each_call_has_thread_id(
+    def test_shared_instance_aggregate_under_overlap(
         self,
-        mock_register: MagicMock,
-        mock_last_seen: MagicMock,
+        _mock_register: MagicMock,
+        _mock_last_seen: MagicMock,
         mock_start_log: MagicMock,
         mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
-        app = ThreadApp()
-
-        with ThreadPoolExecutor(max_workers=4) as executor:
-            futures = [executor.submit(app.worker, [1]) for _ in range(4)]
-            for f in futures:
-                f.result()
-
-        thread_ids = {call[1]["thread_id"] for call in mock_start_log.call_args_list}
-        assert len(thread_ids) >= 1
-
-    @patch(f"{_REGISTRY}.update_parent_log_role")
-    @patch(f"{_REGISTRY}.complete_function_log")
-    @patch(f"{_REGISTRY}.start_function_log", return_value=1)
-    @patch(f"{_REGISTRY}.update_last_seen")
-    @patch(f"{_REGISTRY}.register_function")
-    def test_shared_instance_context_isolation_under_overlap(
-        self,
-        mock_register: MagicMock,
-        mock_last_seen: MagicMock,
-        mock_start_log: MagicMock,
-        mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
-    ) -> None:
+        """Two concurrent calls on shared instance accumulate into aggregate context."""
         app = SharedInstanceRaceApp()
 
         with ThreadPoolExecutor(max_workers=2) as executor:
@@ -223,23 +200,23 @@ class TestConcurrentCalls:
             results = [future.result() for future in futures]
 
         assert sorted(results) == [1, 80]
+        assert mock_start_log.call_count == 1
         assert mock_complete_log.call_count == 2
 
-        solved_values = sorted(call[1]["solved"] for call in mock_complete_log.call_args_list)
-        assert solved_values == [1, 80]
+        last_call = mock_complete_log.call_args_list[-1]
+        assert last_call[1]["solved"] == 81
+        assert last_call[1]["call_count"] == 2
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
     @patch(f"{_REGISTRY}.register_function")
     def test_child_threads_inherit_parent_context_via_wrapper(
         self,
-        mock_register: MagicMock,
-        mock_last_seen: MagicMock,
+        _mock_register: MagicMock,
+        _mock_last_seen: MagicMock,
         mock_start_log: MagicMock,
         mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         app = FanOutApp()
 
@@ -251,18 +228,16 @@ class TestConcurrentCalls:
         assert log_kwargs["solved"] == 12
         assert log_kwargs["failed"] == 0
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
     @patch(f"{_REGISTRY}.register_function")
     def test_wrapped_worker_keeps_parent_context_after_nested_invocation(
         self,
-        mock_register: MagicMock,
-        mock_last_seen: MagicMock,
+        _mock_register: MagicMock,
+        _mock_last_seen: MagicMock,
         mock_start_log: MagicMock,
         mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         app = FanOutNestedWorkerApp()
 
@@ -271,22 +246,16 @@ class TestConcurrentCalls:
         assert result == 3
         assert mock_complete_log.call_count == 2
 
-        rows = [call[1] for call in mock_complete_log.call_args_list]
-        assert any(row["solved"] == 2 and row["failed"] == 0 for row in rows)
-        assert any(row["solved"] == 1 and row["failed"] == 0 for row in rows)
-
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
     @patch(f"{_REGISTRY}.register_function")
     def test_wrap_with_active_context_unbinds_on_worker_exception(
         self,
-        mock_register: MagicMock,
-        mock_last_seen: MagicMock,
+        _mock_register: MagicMock,
+        _mock_last_seen: MagicMock,
         mock_start_log: MagicMock,
         mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         app = FanOutCleanupApp()
 
@@ -296,18 +265,16 @@ class TestConcurrentCalls:
         assert second_error == "RuntimeError"
         assert mock_complete_log.call_count == 1
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
     @patch(f"{_REGISTRY}.register_function")
     def test_wrap_propagates_structlog_contextvars_to_worker_thread(
         self,
-        mock_register: MagicMock,
-        mock_last_seen: MagicMock,
+        _mock_register: MagicMock,
+        _mock_last_seen: MagicMock,
         mock_start_log: MagicMock,
         mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         captured: dict[str, object] = {}
 
@@ -333,18 +300,16 @@ class TestConcurrentCalls:
         assert "call_chain" in captured
         assert "thread_id" in captured
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
     @patch(f"{_REGISTRY}.register_function")
     def test_wrap_cleans_up_structlog_contextvars_after_worker(
         self,
-        mock_register: MagicMock,
-        mock_last_seen: MagicMock,
+        _mock_register: MagicMock,
+        _mock_last_seen: MagicMock,
         mock_start_log: MagicMock,
         mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         after_cleanup: dict[str, object] = {}
 
@@ -372,18 +337,16 @@ class TestConcurrentCalls:
 
         assert "function_id" not in after_cleanup
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
     @patch(f"{_REGISTRY}.register_function")
     def test_child_thread_without_wrapper_raises_runtime_error(
         self,
-        mock_register: MagicMock,
-        mock_last_seen: MagicMock,
+        _mock_register: MagicMock,
+        _mock_last_seen: MagicMock,
         mock_start_log: MagicMock,
         mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         app = FanOutApp()
 
@@ -391,62 +354,20 @@ class TestConcurrentCalls:
             app.run_without_wrapper(4)
 
 
-class TestExecutionOrderSequencing:
-    def setup_method(self) -> None:
-        FunWatchRegistry.reset()
-
-    @patch(f"{_REGISTRY}.update_parent_log_role")
-    @patch(f"{_REGISTRY}.complete_function_log")
-    @patch(f"{_REGISTRY}.start_function_log", return_value=1)
-    @patch(f"{_REGISTRY}.update_last_seen")
-    @patch(f"{_REGISTRY}.register_function")
-    def test_sequential_calls_increment_execution_order(
-        self,
-        mock_register: MagicMock,
-        mock_last_seen: MagicMock,
-        mock_start_log: MagicMock,
-        mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
-    ) -> None:
-        app = ThreadApp()
-        app.simple()
-        app.simple()
-        app.simple()
-
-        execution_orders = [
-            call[1]["execution_order"]
-            for call in mock_start_log.call_args_list
-        ]
-        assert execution_orders == [1, 2, 3]
-
-    def test_counter_cleanup_on_runtime_change(self) -> None:
-        registry = FunWatchRegistry.instance()
-        tid = 1
-
-        assert registry.next_execution_order("runtime_a", tid) == (1, 1)
-        assert registry.next_execution_order("runtime_a", tid) == (2, 2)
-        assert registry.next_execution_order("runtime_a", tid) == (3, 3)
-
-        assert registry.next_execution_order("runtime_b", tid) == (1, 1)
-        assert registry.next_execution_order("runtime_b", tid) == (2, 2)
-
-
 class TestWrapWithActiveContext:
     def setup_method(self) -> None:
         FunWatchRegistry.reset()
 
-    @patch(f"{_REGISTRY}.update_parent_log_role")
     @patch(f"{_REGISTRY}.complete_function_log")
     @patch(f"{_REGISTRY}.start_function_log", return_value=1)
     @patch(f"{_REGISTRY}.update_last_seen")
     @patch(f"{_REGISTRY}.register_function")
     def test_wrap_overrides_thread_id_to_worker_thread(
         self,
-        mock_register: MagicMock,
-        mock_last_seen: MagicMock,
+        _mock_register: MagicMock,
+        _mock_last_seen: MagicMock,
         mock_start_log: MagicMock,
         mock_complete_log: MagicMock,
-        _mock_parent_role: MagicMock,
     ) -> None:
         captured_thread_ids: list[int] = []
         parent_thread_id = threading.get_ident()

--- a/tests/unit/orchestration/test_retention.py
+++ b/tests/unit/orchestration/test_retention.py
@@ -41,9 +41,9 @@ class TestRunCleanup:
 
         cleaner.run_cleanup()
 
-        # 5 tables cleaned: function_log_error, function_log, logs, runtime, command_log
-        assert mock_session.execute.call_count == 5
-        assert mock_session.commit.call_count == 5
+        # 4 tables cleaned: function_log, logs, runtime, command_log
+        assert mock_session.execute.call_count == 4
+        assert mock_session.commit.call_count == 4
 
     def test_logs_when_rows_deleted(self) -> None:
         mock_database = MagicMock()
@@ -59,11 +59,11 @@ class TestRunCleanup:
         cleaner.run_cleanup()
 
         # Should log for each table that had rows deleted
-        assert mock_logger.info.call_count == 5
+        assert mock_logger.info.call_count == 4
         # Verify one of the log messages includes table name and row count
         log_message = mock_logger.info.call_args_list[0][0][0]
         assert "42" in log_message
-        assert "function_log_error" in log_message
+        assert "function_log" in log_message
 
     def test_no_logging_when_zero_rows(self) -> None:
         mock_database = MagicMock()
@@ -98,8 +98,8 @@ class TestRunCleanup:
         cleaner = LogRetentionCleaner(mock_database, settings, logger=MagicMock())
         cleaner.run_cleanup()
 
-        # delete() should be called for each of the 5 tables
-        assert mock_delete.call_count == 5
+        # delete() should be called for each of the 4 tables
+        assert mock_delete.call_count == 4
 
 
 class TestPurgeRemovedApps:

--- a/tests/unit/scraping/test_base_scraper.py
+++ b/tests/unit/scraping/test_base_scraper.py
@@ -131,7 +131,6 @@ class TestSubclassing:
         assert scraper.base_url == "https://example.com"
 
 
-@patch(f"{_REGISTRY}.update_parent_log_role")
 @patch(f"{_REGISTRY}.complete_function_log")
 @patch(f"{_REGISTRY}.start_function_log", return_value=1)
 @patch(f"{_REGISTRY}.update_last_seen")

--- a/tests/unit/scraping/test_progress_tracking.py
+++ b/tests/unit/scraping/test_progress_tracking.py
@@ -72,15 +72,9 @@ class TestIncrementFailed:
         token = registry.bind_context(context)
         try:
             scraper = _make_scraper()
-            scraper.increment_failed(2, error_type="timeout", error_message="Connection timed out")
+            scraper.increment_failed(2)
             assert scraper.failed == 2
             assert context.failed == 2
-            count, types_json, samples_json = context.error_snapshot()
-            assert count == 2
-            assert types_json is not None
-            assert "timeout" in types_json
-            assert samples_json is not None
-            assert "Connection timed out" in samples_json
         finally:
             registry.unbind_context(token)
 


### PR DESCRIPTION
## Work Package
WP-03: @fun_watch decorator & FunctionLog

## Summary
- Remove FunctionLogError table entirely -- errors flow to Logs table via app-level logging
- Add caller_log_id to FunctionLog for thread-to-caller navigability
- Bind thread function_id/function_name in structlog contextvars for accurate error log attribution
- Pass app logger through wrap_with_thread_context for DB persistence of unhandled exception tracebacks
- Extract raise-site module_name/lineno from exception traceback for accurate Logs metadata
- Remove error_type/error_message from increment_failed -- counter-only responsibility
- Simplify FunWatchContext: remove error aggregation, samples, snapshots
- Add abort_exception example demonstrating handled vs unhandled exception patterns

## Changes
- `data_collector/tables/log.py` -- Delete FunctionLogError, add caller_log_id to FunctionLog
- `data_collector/utilities/fun_watch.py` -- Remove error aggregation from FunWatchContext, simplify mark_failed, fix thread function_id/function_name binding, add application_logger to wrap_with_thread_context, extract traceback metadata
- `data_collector/scraping/base.py` -- Remove error_type/error_message from increment_failed, remove logger.error call
- `data_collector/scraping/threaded.py` -- Pass app logger to wrap_with_thread_context, mark thread context failed for unhandled exceptions, update counter handling
- `data_collector/scraping/async_scraper.py` -- Add caller_log_id support, update complete_function_log calls
- `data_collector/orchestration/retention.py` -- Remove FunctionLogError from retention cleanup
- `data_collector/tables/__init__.py` -- Remove FunctionLogError export
- `data_collector/tables/captcha.py` -- Fix stale pattern reference in docstring
- `data_collector/examples/scraping/abort_exception/` -- New example: handled vs unhandled exceptions with traceback verification
- `data_collector/examples/scraping/abort_blocker/main.py` -- App-level error logging, remove error_type kwarg
- `data_collector/examples/scraping/abort_http/main.py` -- App-level error logging, remove error_type kwarg
- `data_collector/examples/fun_watch/03_multithreaded.py` -- Remove FunctionLogError references
- `docs/25. fun-watch.md` -- Remove FunctionLogError section, add Error Handling section, update thread safety docs
- `docs/1.2. data-model.md` -- Remove FunctionLogError from ERD and table spec, add caller_log_id
- `docs/50. roadmap.md` -- Remove FunctionLogError deliverable, update RetentionCleaner description
- `docs/12. captcha.md` -- Fix stale pattern reference
- Tests updated across 7 files to match new API

## Testing
- `ruff check` -- 0 errors on changed files (3 pre-existing in unrelated files)
- `pyright` -- 0 errors, 0 warnings on changed files
- `pytest tests/unit tests/quality` -- 1507 passed
- `python data_collector/utilities/validate_docs.py` -- 43 files validated
- All 7 scraping examples pass with correct data in dc_example schema

## Related
- [docs/25. fun-watch.md](docs/25.%20fun-watch.md) -- @fun_watch specification
- [docs/1.2. data-model.md](docs/1.2.%20data-model.md) -- Data model specification
- [docs/50. roadmap.md](docs/50.%20roadmap.md) -- WP-03 deliverables

Generated with [Claude Code](https://claude.com/claude-code)